### PR TITLE
Add hierarchical course tree UI

### DIFF
--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -149,6 +149,7 @@ export const putModule    = (id: number, d: any)        => putData('moduleById',
 export const deleteModule = (id: number)                => deleteData('moduleById', {}, id)
 
 export const getLessons   = (moduleId: number)          => fetchData('lessonsByModule', {}, moduleId)
+export const getLesson    = (id: number)                => fetchData('lessonById', {}, id)
 export const postLesson   = (moduleId: number, d: any)  => postData('lessonsByModule', d, moduleId)
 export const putLesson    = (id: number, d: any)        => putData('lessonById', d, id)
 export const deleteLesson = (id: number)                => deleteData('lessonById', {}, id)

--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import { TreeView, TreeItem } from '@mui/lab';
+import { Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { getCourses, getModules, getLessons } from 'api';
+
+interface Lesson {
+  id: number;
+  title: string;
+}
+interface Module {
+  id: number;
+  title: string;
+  lessons: Lesson[];
+}
+interface Course {
+  id: number;
+  title: string;
+  modules: Module[];
+}
+
+const CoursesPage = () => {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const coursesData = await getCourses();
+        const coursesWithModules: Course[] = await Promise.all(
+          coursesData.map(async (course: any) => {
+            const modulesData = await getModules(course.id);
+            const modulesWithLessons: Module[] = await Promise.all(
+              modulesData.map(async (mod: any) => ({
+                ...mod,
+                lessons: await getLessons(mod.id)
+              }))
+            );
+            return { ...course, modules: modulesWithLessons };
+          })
+        );
+        setCourses(coursesWithModules);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleLessonClick = (
+    courseId: number,
+    moduleId: number,
+    lessonId: number
+  ) => {
+    navigate(`/courses/${courseId}/modules/${moduleId}/lessons/${lessonId}`);
+  };
+
+  return (
+    <div>
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        Курсы
+      </Typography>
+      <TreeView>
+        {courses.map((course) => (
+          <TreeItem
+            key={course.id}
+            nodeId={`c-${course.id}`}
+            label={course.title}
+          >
+            {course.modules.map((mod) => (
+              <TreeItem
+                key={mod.id}
+                nodeId={`m-${mod.id}`}
+                label={mod.title}
+              >
+                {mod.lessons.map((lesson) => (
+                  <TreeItem
+                    key={lesson.id}
+                    nodeId={`l-${lesson.id}`}
+                    label={lesson.title}
+                    onClick={() =>
+                      handleLessonClick(course.id, mod.id, lesson.id)
+                    }
+                  />
+                ))}
+              </TreeItem>
+            ))}
+          </TreeItem>
+        ))}
+      </TreeView>
+    </div>
+  );
+};
+
+export default CoursesPage;

--- a/src/pages/lessons-page/LessonViewPage.tsx
+++ b/src/pages/lessons-page/LessonViewPage.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Stack, Typography } from '@mui/material';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getLessons, getLesson } from 'api';
+
+interface Lesson {
+  id: number;
+  title: string;
+  content: string;
+}
+
+const LessonViewPage = () => {
+  const { lessonId, moduleId, courseId } = useParams();
+  const navigate = useNavigate();
+  const [lesson, setLesson] = useState<Lesson | null>(null);
+  const [lessons, setLessons] = useState<Lesson[]>([]);
+
+  useEffect(() => {
+    if (!moduleId) return;
+    (async () => {
+      const allLessons = await getLessons(Number(moduleId));
+      setLessons(allLessons);
+    })();
+  }, [moduleId]);
+
+  useEffect(() => {
+    if (!lessonId) return;
+    (async () => {
+      const data = await getLesson(Number(lessonId));
+      setLesson(data);
+    })();
+  }, [lessonId]);
+
+  if (!lesson) return null;
+
+  const index = lessons.findIndex((l) => l.id === lesson.id);
+  const prevLesson = lessons[index - 1];
+  const nextLesson = lessons[index + 1];
+
+  return (
+    <div>
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        {lesson.title}
+      </Typography>
+      <div dangerouslySetInnerHTML={{ __html: lesson.content }} />
+      <Stack direction="row" justifyContent="space-between" sx={{ mt: 3 }}>
+        <Button
+          disabled={!prevLesson}
+          onClick={() =>
+            prevLesson &&
+            navigate(
+              `/courses/${courseId}/modules/${moduleId}/lessons/${prevLesson.id}`
+            )
+          }
+        >
+          Предыдущий
+        </Button>
+        <Button
+          disabled={!nextLesson}
+          onClick={() =>
+            nextLesson &&
+            navigate(
+              `/courses/${courseId}/modules/${moduleId}/lessons/${nextLesson.id}`
+            )
+          }
+        >
+          Следующий
+        </Button>
+      </Stack>
+    </div>
+  );
+};
+
+export default LessonViewPage;

--- a/src/pages/lessons-page/LessonsPage.tsx
+++ b/src/pages/lessons-page/LessonsPage.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+  TextField,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle
+} from '@mui/material';
+import JoditEditor from 'jodit-react';
+import { useParams } from 'react-router-dom';
+import { getLessons, postLesson, putLesson, deleteLesson } from 'api';
+
+interface Lesson {
+  id: number;
+  title: string;
+  content: string;
+}
+
+const LessonsPage = () => {
+  const { moduleId, courseId } = useParams();
+  const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [open, setOpen] = useState(false);
+  const [editId, setEditId] = useState<number | null>(null);
+  const [title, setTitle] = useState('');
+  const editor = useRef(null);
+  const [content, setContent] = useState('');
+
+  const load = async () => {
+    if (!moduleId) return;
+    const data = await getLessons(Number(moduleId));
+    setLessons(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, [moduleId]);
+
+  const handleSave = async () => {
+    if (!moduleId) return;
+    try {
+      if (editId) {
+        await putLesson(editId, { title, content, module_id: Number(moduleId) });
+      } else {
+        await postLesson(Number(moduleId), { title, content });
+      }
+      setOpen(false);
+      setTitle('');
+      setContent('');
+      setEditId(null);
+      load();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleEdit = (lesson: Lesson) => {
+    setEditId(lesson.id);
+    setTitle(lesson.title);
+    setContent(lesson.content);
+    setOpen(true);
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteLesson(id);
+    load();
+  };
+
+  return (
+    <div>
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        Уроки
+      </Typography>
+      <Stack direction="row" justifyContent="flex-end" sx={{ mb: 2 }}>
+        <Button variant="contained" color="success" onClick={() => setOpen(true)}>
+          Добавить урок
+        </Button>
+      </Stack>
+      <List>
+        {lessons.map((lesson) => (
+          <ListItem
+            key={lesson.id}
+            secondaryAction={
+              <>
+                <Button onClick={() => handleEdit(lesson)}>Редактировать</Button>
+                <Button color="error" onClick={() => handleDelete(lesson.id)}>
+                  Удалить
+                </Button>
+              </>
+            }
+          >
+            <ListItemText
+              primary={lesson.title}
+              onClick={() => window.location.assign(`/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}`)}
+            />
+          </ListItem>
+        ))}
+      </List>
+      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="md" fullWidth>
+        <DialogTitle>{editId ? 'Редактировать урок' : 'Новый урок'}</DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={2}>
+            <TextField
+              label="Название"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <JoditEditor ref={editor} value={content} onBlur={setContent} />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setOpen(false)}>Отмена</Button>
+          <Button onClick={handleSave} variant="contained" color="success">
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+};
+
+export default LessonsPage;

--- a/src/pages/modules-page/ModulesPage.tsx
+++ b/src/pages/modules-page/ModulesPage.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { List, ListItemButton, ListItemText, Typography } from '@mui/material';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getModules } from 'api';
+
+const ModulesPage = () => {
+  const { courseId } = useParams();
+  const [modules, setModules] = useState<any[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!courseId) return;
+    (async () => {
+      try {
+        const m = await getModules(Number(courseId));
+        setModules(m);
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, [courseId]);
+
+  return (
+    <div>
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        Модули курса
+      </Typography>
+      <List>
+        {modules.map((m) => (
+          <ListItemButton
+            key={m.id}
+            onClick={() => navigate(`/courses/${courseId}/modules/${m.id}/lessons`)}
+          >
+            <ListItemText primary={m.title} />
+          </ListItemButton>
+        ))}
+      </List>
+    </div>
+  );
+};
+
+export default ModulesPage;

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -11,6 +11,7 @@ import TestPage from 'pages/TestPage/TestPage';
 import CoursesPage from 'pages/courses-page/CoursesPage';
 import ModulesPage from 'pages/modules-page/ModulesPage';
 import LessonsPage from 'pages/lessons-page/LessonsPage';
+import LessonViewPage from 'pages/lessons-page/LessonViewPage';
 
 
 // ==============================|| MAIN ROUTING ||============================== //
@@ -78,6 +79,10 @@ const MainRoutes = {
         {
           path: '/courses/:courseId/modules/:moduleId/lessons',
           element: <LessonsPage />
+        },
+        {
+          path: '/courses/:courseId/modules/:moduleId/lessons/:lessonId',
+          element: <LessonViewPage />
         },
       ]
     },


### PR DESCRIPTION
## Summary
- implement Course/Module/Lesson pages
- allow hierarchical navigation with MUI TreeView
- support lesson CRUD with Jodit editor and next/prev navigation
- export new lesson API and update routes

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684812ebd23c8322a31abb778a09678f