### PR TITLE
Add video support for lessons

### DIFF
--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -41,12 +41,12 @@ import JoditEditor from 'jodit-react'
 import MainCard from '../../components/MainCard'
 import LessonsPage from '../lessons-page/LessonsPage'
 import LessonViewPage from '../lessons-page/LessonViewPage'
-import { width } from '@mui/system'
 
 interface Lesson {
   id: number
   title: string
   content?: string
+  video?: string
 }
 
 interface Module {
@@ -81,6 +81,7 @@ const CoursesPage = () => {
   const [editingLessonId, setEditingLessonId] = useState<number | null>(null)
   const [lessonTitle, setLessonTitle] = useState('')
   const [lessonContent, setLessonContent] = useState('')
+  const [lessonVideo, setLessonVideo] = useState('')
   const editor = useRef(null)
 
   // Состояние для выбранного урока
@@ -252,6 +253,7 @@ const CoursesPage = () => {
     setEditingLessonId(null)
     setLessonTitle('')
     setLessonContent('')
+    setLessonVideo('')
     setOpenLessonDialog(true)
   }
 
@@ -261,18 +263,29 @@ const CoursesPage = () => {
     setEditingLessonId(lesson.id)
     setLessonTitle(lesson.title)
     setLessonContent(lesson.content || '')
+    setLessonVideo(lesson.video || '')
     setOpenLessonDialog(true)
+  }
+
+  const handleLessonDialogClose = () => {
+    setOpenLessonDialog(false)
+    setEditingLessonId(null)
+    setLessonTitle('')
+    setLessonContent('')
+    setLessonVideo('')
   }
 
   const saveLesson = async () => {
     if (!lessonModuleId) return
     try {
+      const payload = { title: lessonTitle, content: lessonContent, video: lessonVideo, module_id: lessonModuleId }
       if (editingLessonId) {
-        await putLesson(editingLessonId, { title: lessonTitle, content: lessonContent, module_id: lessonModuleId })
+        await putLesson(editingLessonId, payload)
       } else {
-        await postLesson(lessonModuleId, { title: lessonTitle, content: lessonContent })
+        await postLesson(lessonModuleId, payload)
       }
       setOpenLessonDialog(false)
+      setLessonVideo('')
       const lessonsData = await getLessons(lessonModuleId)
       setCourses(prev =>
         prev.map(c =>
@@ -435,16 +448,17 @@ const CoursesPage = () => {
           <Button onClick={saveModule} variant="contained" color="success">Сохранить</Button>
         </DialogActions>
       </Dialog>
-      <Dialog open={openLessonDialog} onClose={() => setOpenLessonDialog(false)} maxWidth="md" fullWidth>
+      <Dialog open={openLessonDialog} onClose={handleLessonDialogClose} maxWidth="md" fullWidth>
         <DialogTitle>{editingLessonId ? 'Редактировать урок' : 'Новый урок'}</DialogTitle>
         <DialogContent dividers>
           <Stack spacing={2}>
             <TextField label="Название" value={lessonTitle} onChange={e => setLessonTitle(e.target.value)} />
+            <TextField label="Ссылка на видео" value={lessonVideo} onChange={e => setLessonVideo(e.target.value)} />
             <JoditEditor ref={editor} value={lessonContent} onBlur={setLessonContent} />
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setOpenLessonDialog(false)}>Отмена</Button>
+          <Button onClick={handleLessonDialogClose}>Отмена</Button>
           <Button onClick={saveLesson} variant="contained" color="success">Сохранить</Button>
         </DialogActions>
       </Dialog>

--- a/src/pages/lessons-page/LessonViewPage.tsx
+++ b/src/pages/lessons-page/LessonViewPage.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Stack, Typography } from '@mui/material';
+import { Button, Stack, Typography, Box } from '@mui/material';
 import { getLessons } from 'api';
 
 interface Lesson {
   id: number;
   title: string;
   content: string;
+  video?: string;
 }
 
 interface LessonViewPageProps {
@@ -66,11 +67,27 @@ const LessonViewPage: React.FC<LessonViewPageProps> = ({
     }
   };
 
+  const getEmbedUrl = (url: string) => {
+    const match = url.match(/(?:youtube\.com\/(?:.*v=|embed\/)|youtu\.be\/)([^&?/]+)/);
+    return match ? `https://www.youtube.com/embed/${match[1]}` : url;
+  };
+
   return (
     <div>
       <Typography variant="h4" sx={{ mb: 2 }}>
         {lesson.title}
       </Typography>
+      {lesson.video && (
+        <Box sx={{ mb: 2 }}>
+          <iframe
+            width="100%"
+            height="400"
+            src={getEmbedUrl(lesson.video)}
+            title="Видео урока"
+            allowFullScreen
+          />
+        </Box>
+      )}
       <div dangerouslySetInnerHTML={{ __html: lesson.content }} />
       <Stack direction="row" justifyContent="space-between" sx={{ mt: 3 }}>
         <Button

--- a/src/pages/lessons-page/LessonsPage.tsx
+++ b/src/pages/lessons-page/LessonsPage.tsx
@@ -20,6 +20,7 @@ interface Lesson {
   id: number;
   title: string;
   content: string;
+  video?: string;
 }
 
 const LessonsPage = () => {
@@ -30,6 +31,7 @@ const LessonsPage = () => {
   const [title, setTitle] = useState('');
   const editor = useRef(null);
   const [content, setContent] = useState('');
+  const [video, setVideo] = useState('');
 
   const load = async () => {
     if (!moduleId) return;
@@ -44,14 +46,16 @@ const LessonsPage = () => {
   const handleSave = async () => {
     if (!moduleId) return;
     try {
+      const payload = { title, content, video, module_id: Number(moduleId) };
       if (editId) {
-        await putLesson(editId, { title, content, module_id: Number(moduleId) });
+        await putLesson(editId, payload);
       } else {
-        await postLesson(Number(moduleId), { title, content });
+        await postLesson(Number(moduleId), payload);
       }
       setOpen(false);
       setTitle('');
       setContent('');
+      setVideo('');
       setEditId(null);
       load();
     } catch (e) {
@@ -63,7 +67,24 @@ const LessonsPage = () => {
     setEditId(lesson.id);
     setTitle(lesson.title);
     setContent(lesson.content);
+    setVideo(lesson.video || '');
     setOpen(true);
+  };
+
+  const handleAdd = () => {
+    setEditId(null);
+    setTitle('');
+    setContent('');
+    setVideo('');
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setEditId(null);
+    setTitle('');
+    setContent('');
+    setVideo('');
   };
 
   const handleDelete = async (id: number) => {
@@ -77,7 +98,7 @@ const LessonsPage = () => {
         Уроки
       </Typography>
       <Stack direction="row" justifyContent="flex-end" sx={{ mb: 2 }}>
-        <Button variant="contained" color="success" onClick={() => setOpen(true)}>
+        <Button variant="contained" color="success" onClick={handleAdd}>
           Добавить урок
         </Button>
       </Stack>
@@ -101,7 +122,7 @@ const LessonsPage = () => {
           </ListItem>
         ))}
       </List>
-      <Dialog open={open} onClose={() => setOpen(false)} maxWidth="md" fullWidth>
+      <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
         <DialogTitle>{editId ? 'Редактировать урок' : 'Новый урок'}</DialogTitle>
         <DialogContent dividers>
           <Stack spacing={2}>
@@ -110,11 +131,16 @@ const LessonsPage = () => {
               value={title}
               onChange={(e) => setTitle(e.target.value)}
             />
+            <TextField
+              label="Ссылка на видео"
+              value={video}
+              onChange={(e) => setVideo(e.target.value)}
+            />
             <JoditEditor ref={editor} value={content} onBlur={setContent} />
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setOpen(false)}>Отмена</Button>
+          <Button onClick={handleClose}>Отмена</Button>
           <Button onClick={handleSave} variant="contained" color="success">
             Сохранить
           </Button>


### PR DESCRIPTION
## Summary
- extend lesson interfaces with `video` attribute
- allow entering a video link when creating or editing lessons
- show YouTube video in lesson view if available

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: numerous missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684a9a51ed3083229a839b7f83daa224