### PR TITLE
Improve course creation with modules

### DIFF
--- a/src/components/CourseFormDialog.tsx
+++ b/src/components/CourseFormDialog.tsx
@@ -1,0 +1,197 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Stack,
+  Typography,
+  IconButton,
+  Select,
+  MenuItem,
+  InputLabel,
+  FormControl
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+interface LessonForm {
+  id?: number;
+  title: string;
+  content?: string;
+  video?: string;
+}
+
+interface ModuleForm {
+  id?: number;
+  title: string;
+  description?: string;
+  lessons: LessonForm[];
+}
+
+export interface CourseFormData {
+  title: string;
+  description?: string;
+  accessType: 'public' | 'group' | 'user';
+  accessId?: string;
+  modules: ModuleForm[];
+}
+
+interface CourseFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (data: CourseFormData) => void;
+  course?: CourseFormData;
+}
+
+const emptyLesson = (): LessonForm => ({ title: '', content: '', video: '' });
+const emptyModule = (): ModuleForm => ({ title: '', description: '', lessons: [emptyLesson()] });
+
+const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSave, course }) => {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [accessType, setAccessType] = useState<'public' | 'group' | 'user'>('public');
+  const [accessId, setAccessId] = useState('');
+  const [modules, setModules] = useState<ModuleForm[]>([emptyModule()]);
+
+  useEffect(() => {
+    if (course) {
+      setTitle(course.title);
+      setDescription(course.description || '');
+      setAccessType(course.accessType);
+      setAccessId(course.accessId || '');
+      setModules(course.modules.length ? course.modules : [emptyModule()]);
+    } else if (open) {
+      setTitle('');
+      setDescription('');
+      setAccessType('public');
+      setAccessId('');
+      setModules([emptyModule()]);
+    }
+  }, [course, open]);
+
+  const handleModuleChange = (index: number, field: keyof ModuleForm, value: string) => {
+    setModules((prev) => {
+      const updated = [...prev];
+      (updated[index] as any)[field] = value;
+      return updated;
+    });
+  };
+
+  const handleLessonChange = (moduleIndex: number, lessonIndex: number, field: keyof LessonForm, value: string) => {
+    setModules((prev) => {
+      const updated = [...prev];
+      (updated[moduleIndex].lessons[lessonIndex] as any)[field] = value;
+      return updated;
+    });
+  };
+
+  const addModule = () => setModules((prev) => [...prev, emptyModule()]);
+  const removeModule = (index: number) => setModules((prev) => prev.filter((_, i) => i !== index));
+
+  const addLesson = (moduleIndex: number) => {
+    setModules((prev) => {
+      const updated = [...prev];
+      updated[moduleIndex].lessons.push(emptyLesson());
+      return updated;
+    });
+  };
+  const removeLesson = (moduleIndex: number, lessonIndex: number) => {
+    setModules((prev) => {
+      const updated = [...prev];
+      updated[moduleIndex].lessons = updated[moduleIndex].lessons.filter((_, i) => i !== lessonIndex);
+      return updated;
+    });
+  };
+
+  const handleSave = () => {
+    onSave({ title, description, accessType, accessId, modules });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>{course ? 'Редактировать курс' : 'Новый курс'}</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField fullWidth label="Название" value={title} onChange={(e) => setTitle(e.target.value)} />
+          <TextField
+            fullWidth
+            label="Описание"
+            multiline
+            minRows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <FormControl>
+            <InputLabel id="access-label">Права доступа</InputLabel>
+            <Select labelId="access-label" value={accessType} label="Права доступа" onChange={(e) => setAccessType(e.target.value as any)}>
+              <MenuItem value="public">Общий</MenuItem>
+              <MenuItem value="group">Для группы</MenuItem>
+              <MenuItem value="user">Для пользователя</MenuItem>
+            </Select>
+          </FormControl>
+          {(accessType === 'group' || accessType === 'user') && (
+            <TextField
+              label={accessType === 'group' ? 'ID группы' : 'ID пользователя'}
+              value={accessId}
+              onChange={(e) => setAccessId(e.target.value)}
+            />
+          )}
+          <Typography variant="h6">Модули и уроки</Typography>
+          {modules.map((mod, modIndex) => (
+            <Stack key={modIndex} spacing={1} sx={{ border: '1px solid #ccc', p: 2, borderRadius: 1 }}>
+              <Stack direction="row" alignItems="center" spacing={1}>
+                <TextField
+                  label="Название модуля"
+                  value={mod.title}
+                  onChange={(e) => handleModuleChange(modIndex, 'title', e.target.value)}
+                  fullWidth
+                />
+                <IconButton onClick={() => removeModule(modIndex)}>
+                  <DeleteIcon />
+                </IconButton>
+              </Stack>
+              <TextField
+                label="Описание"
+                multiline
+                minRows={2}
+                value={mod.description}
+                onChange={(e) => handleModuleChange(modIndex, 'description', e.target.value)}
+              />
+              <Typography variant="subtitle1">Уроки</Typography>
+              {mod.lessons.map((les, lesIndex) => (
+                <Stack key={lesIndex} direction="row" spacing={1} alignItems="center">
+                  <TextField
+                    label="Название"
+                    value={les.title}
+                    onChange={(e) => handleLessonChange(modIndex, lesIndex, 'title', e.target.value)}
+                    fullWidth
+                  />
+                  <IconButton onClick={() => removeLesson(modIndex, lesIndex)}>
+                    <DeleteIcon />
+                  </IconButton>
+                </Stack>
+              ))}
+              <Button startIcon={<AddIcon />} onClick={() => addLesson(modIndex)}>
+                Добавить урок
+              </Button>
+            </Stack>
+          ))}
+          <Button startIcon={<AddIcon />} onClick={addModule}>
+            Добавить модуль
+          </Button>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Отмена</Button>
+        <Button onClick={handleSave} variant="contained" color="success">
+          Сохранить
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default CourseFormDialog;

--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react'
+import React, { useEffect, useState, useRef } from 'react';
 import {
   List,
   ListItem,
@@ -20,14 +20,14 @@ import {
   Card,
   CardContent,
   Chip
-} from '@mui/material'
-import ExpandLess from '@mui/icons-material/ExpandLess'
-import ExpandMore from '@mui/icons-material/ExpandMore'
-import EditIcon from '@mui/icons-material/Edit'
-import DeleteIcon from '@mui/icons-material/Delete'
-import AddIcon from '@mui/icons-material/Add'
-import LibraryBooksIcon from '@mui/icons-material/LibraryBooks'
-import { useNavigate } from 'react-router-dom'
+} from '@mui/material';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import LibraryBooksIcon from '@mui/icons-material/LibraryBooks';
+import { useNavigate } from 'react-router-dom';
 import {
   getCourses,
   getModules,
@@ -45,416 +45,444 @@ import {
   getUserCourses,
   getCourseProgress,
   completeLesson
-} from 'api'
-import JoditEditor from 'jodit-react'
-import MainCard from '../../components/MainCard'
-import LessonsPage from '../lessons-page/LessonsPage'
-import LessonViewPage from '../lessons-page/LessonViewPage'
-import { Context } from '../..'
+} from 'api';
+import JoditEditor from 'jodit-react';
+import MainCard from '../../components/MainCard';
+import LessonsPage from '../lessons-page/LessonsPage';
+import LessonViewPage from '../lessons-page/LessonViewPage';
+import { Context } from '../..';
+import CourseFormDialog, { CourseFormData } from '../../components/CourseFormDialog';
 
 interface Lesson {
-  id: number
-  title: string
-  content?: string
-  video?: string
+  id: number;
+  title: string;
+  content?: string;
+  video?: string;
 }
 
 interface Module {
-  id: number
-  title: string
-  description?: string
-  lessons?: Lesson[]
-  open?: boolean
+  id: number;
+  title: string;
+  description?: string;
+  lessons?: Lesson[];
+  open?: boolean;
 }
 
 interface Course {
-  id: number
-  title: string
-  description?: string
-  modules?: Module[]
-  open?: boolean
-  hasAccess?: boolean
-  progress?: number
+  id: number;
+  title: string;
+  description?: string;
+  modules?: Module[];
+  open?: boolean;
+  hasAccess?: boolean;
+  progress?: number;
 }
 
 const CoursesPage = () => {
-  const { authStore } = React.useContext(Context)
-  const { roleCode, userId } = authStore
-  const [courses, setCourses] = useState<Course[]>([])
-  const navigate = useNavigate()
-  const [openCourseDialog, setOpenCourseDialog] = useState(false)
-  const [editingCourseId, setEditingCourseId] = useState<number | null>(null)
-  const [courseTitle, setCourseTitle] = useState('')
-  const [courseDescription, setCourseDescription] = useState('')
+  const { authStore } = React.useContext(Context);
+  const { roleCode, userId } = authStore;
+  const [courses, setCourses] = useState<Course[]>([]);
+  const navigate = useNavigate();
+  const [openCourseDialog, setOpenCourseDialog] = useState(false);
+  const [editingCourseId, setEditingCourseId] = useState<number | null>(null);
+  const [courseFormData, setCourseFormData] = useState<CourseFormData | undefined>(undefined);
 
-  const [openModuleDialog, setOpenModuleDialog] = useState(false)
-  const [moduleCourseId, setModuleCourseId] = useState<number | null>(null)
-  const [editingModuleId, setEditingModuleId] = useState<number | null>(null)
-  const [moduleTitle, setModuleTitle] = useState('')
-  const [moduleDescription, setModuleDescription] = useState('')
+  const [openModuleDialog, setOpenModuleDialog] = useState(false);
+  const [moduleCourseId, setModuleCourseId] = useState<number | null>(null);
+  const [editingModuleId, setEditingModuleId] = useState<number | null>(null);
+  const [moduleTitle, setModuleTitle] = useState('');
+  const [moduleDescription, setModuleDescription] = useState('');
 
-  const [openLessonDialog, setOpenLessonDialog] = useState(false)
-  const [lessonCourseId, setLessonCourseId] = useState<number | null>(null)
-  const [lessonModuleId, setLessonModuleId] = useState<number | null>(null)
-  const [editingLessonId, setEditingLessonId] = useState<number | null>(null)
-  const [lessonTitle, setLessonTitle] = useState('')
-  const [lessonContent, setLessonContent] = useState('')
-  const [lessonVideo, setLessonVideo] = useState('')
-  const editor = useRef(null)
+  const [openLessonDialog, setOpenLessonDialog] = useState(false);
+  const [lessonCourseId, setLessonCourseId] = useState<number | null>(null);
+  const [lessonModuleId, setLessonModuleId] = useState<number | null>(null);
+  const [editingLessonId, setEditingLessonId] = useState<number | null>(null);
+  const [lessonTitle, setLessonTitle] = useState('');
+  const [lessonContent, setLessonContent] = useState('');
+  const [lessonVideo, setLessonVideo] = useState('');
+  const editor = useRef(null);
 
   const handleCreateTestForCourse = (courseId: number) => {
-    navigate(`/main-page/new-test?course=${courseId}`)
-  }
+    navigate(`/main-page/new-test?course=${courseId}`);
+  };
 
   const handleCreateTestForModule = (courseId: number, moduleId: number) => {
-    navigate(`/main-page/new-test?course=${courseId}&module=${moduleId}`)
-  }
+    navigate(`/main-page/new-test?course=${courseId}&module=${moduleId}`);
+  };
 
   // Состояние для выбранного урока
-  const [selectedCourseId, setSelectedCourseId] = useState<number | undefined>(undefined)
-  const [selectedModuleId, setSelectedModuleId] = useState<number | undefined>(undefined)
-  const [selectedLessonId, setSelectedLessonId] = useState<number | undefined>(undefined)
+  const [selectedCourseId, setSelectedCourseId] = useState<number | undefined>(undefined);
+  const [selectedModuleId, setSelectedModuleId] = useState<number | undefined>(undefined);
+  const [selectedLessonId, setSelectedLessonId] = useState<number | undefined>(undefined);
 
   const loadCourses = async () => {
     try {
-      const data = await getCourses()
-      let userCourses: number[] = []
+      const data = await getCourses();
+      let userCourses: number[] = [];
       if (userId) {
         try {
-          const ucs = await getUserCourses(userId)
-          userCourses = ucs.map((uc: any) => uc.course_id)
+          const ucs = await getUserCourses(userId);
+          userCourses = ucs.map((uc: any) => uc.course_id);
         } catch (e) {
-          console.error(e)
+          console.error(e);
         }
       }
       const coursesWithAccess = await Promise.all(
         data.map(async (c: Course) => {
-          const hasAccess = userCourses.includes(c.id)
-          let progress = 0
+          const hasAccess = userCourses.includes(c.id);
+          let progress = 0;
           if (hasAccess) {
             try {
-              const p = await getCourseProgress(c.id)
-              progress = p.percent
+              const p = await getCourseProgress(c.id);
+              progress = p.percent;
             } catch (e) {
-              console.error(e)
+              console.error(e);
             }
           }
-          return { ...c, hasAccess, progress }
+          return { ...c, hasAccess, progress };
         })
-      )
-      setCourses(coursesWithAccess)
+      );
+      setCourses(coursesWithAccess);
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
   useEffect(() => {
-    loadCourses()
-  }, [])
+    loadCourses();
+  }, []);
 
   const toggleCourse = async (courseId: number) => {
-    const course = courses.find(c => c.id === courseId)
-    if (!course) return
+    const course = courses.find((c) => c.id === courseId);
+    if (!course) return;
     if (roleCode !== 'admin' && !course.hasAccess) {
-      setSelectedCourseId(courseId)
-      setSelectedModuleId(undefined)
-      setSelectedLessonId(undefined)
-      return
+      setSelectedCourseId(courseId);
+      setSelectedModuleId(undefined);
+      setSelectedLessonId(undefined);
+      return;
     }
     if (!course.modules) {
       try {
-        const modulesData = await getModules(courseId)
-        setCourses(prev =>
-          prev.map(c =>
-            c.id === courseId ? { ...c, modules: modulesData, open: !c.open } : c
-          )
-        )
+        const modulesData = await getModules(courseId);
+        setCourses((prev) => prev.map((c) => (c.id === courseId ? { ...c, modules: modulesData, open: !c.open } : c)));
       } catch (e) {
-        console.error(e)
+        console.error(e);
       }
     } else {
-      setCourses(prev =>
-        prev.map(c =>
-          c.id === courseId ? { ...c, open: !c.open } : c
-        )
-      )
+      setCourses((prev) => prev.map((c) => (c.id === courseId ? { ...c, open: !c.open } : c)));
     }
 
-    setSelectedCourseId(courseId)
-    setSelectedModuleId(undefined)
-    setSelectedLessonId(undefined)
-  }
+    setSelectedCourseId(courseId);
+    setSelectedModuleId(undefined);
+    setSelectedLessonId(undefined);
+  };
 
   const toggleModule = async (courseId: number, moduleId: number) => {
-    const course = courses.find(c => c.id === courseId)
-    if (!course || !course.modules) return
-    const mod = course.modules.find(m => m.id === moduleId)
-    if (!mod) return
+    const course = courses.find((c) => c.id === courseId);
+    if (!course || !course.modules) return;
+    const mod = course.modules.find((m) => m.id === moduleId);
+    if (!mod) return;
     if (!mod.lessons) {
       try {
-        const lessonsData = await getLessons(moduleId)
-        setCourses(prev =>
-          prev.map(c =>
+        const lessonsData = await getLessons(moduleId);
+        setCourses((prev) =>
+          prev.map((c) =>
             c.id === courseId
               ? {
-                ...c,
-                modules: c.modules?.map(m =>
-                  m.id === moduleId ? { ...m, lessons: lessonsData, open: !m.open } : m
-                )
-              }
+                  ...c,
+                  modules: c.modules?.map((m) => (m.id === moduleId ? { ...m, lessons: lessonsData, open: !m.open } : m))
+                }
               : c
           )
-        )
+        );
       } catch (e) {
-        console.error(e)
+        console.error(e);
       }
     } else {
-      setCourses(prev =>
-        prev.map(c =>
+      setCourses((prev) =>
+        prev.map((c) =>
           c.id === courseId
             ? {
-              ...c,
-              modules: c.modules?.map(m =>
-                m.id === moduleId ? { ...m, open: !m.open } : m
-              )
-            }
+                ...c,
+                modules: c.modules?.map((m) => (m.id === moduleId ? { ...m, open: !m.open } : m))
+              }
             : c
         )
-      )
+      );
     }
 
-    setSelectedCourseId(courseId)
-    setSelectedModuleId(moduleId)
-    setSelectedLessonId(undefined)
-  }
+    setSelectedCourseId(courseId);
+    setSelectedModuleId(moduleId);
+    setSelectedLessonId(undefined);
+  };
 
   const handleAddCourse = () => {
-    setEditingCourseId(null)
-    setCourseTitle('')
-    setCourseDescription('')
-    setOpenCourseDialog(true)
-  }
+    setEditingCourseId(null);
+    setCourseFormData(undefined);
+    setOpenCourseDialog(true);
+  };
 
-  const handleEditCourse = (course: Course) => {
-    setEditingCourseId(course.id)
-    setCourseTitle(course.title)
-    setCourseDescription(course.description || '')
-    setOpenCourseDialog(true)
-  }
-
-  const saveCourse = async () => {
+  const handleEditCourse = async (course: Course) => {
+    setEditingCourseId(course.id);
     try {
-      if (editingCourseId) {
-        await putCourse(editingCourseId, { title: courseTitle, description: courseDescription })
-      } else {
-        await postCourse({ title: courseTitle, description: courseDescription })
-      }
-      setOpenCourseDialog(false)
-      setCourseTitle('')
-      setCourseDescription('')
-      setEditingCourseId(null)
-      await loadCourses()
+      const modulesData = await getModules(course.id);
+      const modulesWithLessons = await Promise.all(
+        modulesData.map(async (m: Module) => {
+          const lessonsData = await getLessons(m.id);
+          return { ...m, lessons: lessonsData };
+        })
+      );
+      const formData: CourseFormData = {
+        title: course.title,
+        description: course.description || '',
+        accessType: 'public',
+        modules: modulesWithLessons.map((m) => ({
+          id: m.id,
+          title: m.title,
+          description: m.description || '',
+          lessons: m.lessons?.map((l) => ({ id: l.id, title: l.title, content: l.content || '', video: l.video || '' })) || []
+        }))
+      };
+      setCourseFormData(formData);
     } catch (e) {
-      console.error(e)
+      console.error(e);
+      setCourseFormData({ title: course.title, description: course.description || '', accessType: 'public', modules: [] });
     }
-  }
+    setOpenCourseDialog(true);
+  };
+
+  const saveCourse = async (data: CourseFormData) => {
+    try {
+      let id = editingCourseId;
+      if (editingCourseId) {
+        await putCourse(editingCourseId, { title: data.title, description: data.description });
+      } else {
+        const res = await postCourse({ title: data.title, description: data.description });
+        id = res?.id;
+      }
+      if (!id) return;
+      for (const mod of data.modules) {
+        let modId = mod.id;
+        if (modId) {
+          await putModule(modId, { title: mod.title, description: mod.description });
+        } else {
+          const m = await postModule(id, { title: mod.title, description: mod.description });
+          modId = m?.id;
+        }
+        if (!modId) continue;
+        for (const les of mod.lessons) {
+          if (les.id) {
+            await putLesson(les.id, { title: les.title, content: les.content, video: les.video });
+          } else {
+            await postLesson(modId, { title: les.title, content: les.content, video: les.video });
+          }
+        }
+      }
+      setOpenCourseDialog(false);
+      setEditingCourseId(null);
+      setCourseFormData(undefined);
+      await loadCourses();
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   const handleDeleteCourse = async (id: number) => {
-    if (!window.confirm('Удалить курс?')) return
+    if (!window.confirm('Удалить курс?')) return;
     try {
-      await deleteCourse(id)
-      await loadCourses()
+      await deleteCourse(id);
+      await loadCourses();
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
   const handleEnrollCourse = async (id: number) => {
     try {
-      await enrollCourse(id)
-      await loadCourses()
+      await enrollCourse(id);
+      await loadCourses();
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
   const handleAddModule = (courseId: number) => {
-    setModuleCourseId(courseId)
-    setEditingModuleId(null)
-    setModuleTitle('')
-    setModuleDescription('')
-    setOpenModuleDialog(true)
-  }
+    setModuleCourseId(courseId);
+    setEditingModuleId(null);
+    setModuleTitle('');
+    setModuleDescription('');
+    setOpenModuleDialog(true);
+  };
 
   const handleEditModule = (courseId: number, module: Module) => {
-    setModuleCourseId(courseId)
-    setEditingModuleId(module.id)
-    setModuleTitle(module.title)
-    setModuleDescription(module.description || '')
-    setOpenModuleDialog(true)
-  }
+    setModuleCourseId(courseId);
+    setEditingModuleId(module.id);
+    setModuleTitle(module.title);
+    setModuleDescription(module.description || '');
+    setOpenModuleDialog(true);
+  };
 
   const saveModule = async () => {
-    if (!moduleCourseId) return
+    if (!moduleCourseId) return;
     try {
       if (editingModuleId) {
-        await putModule(editingModuleId, { title: moduleTitle, description: moduleDescription })
+        await putModule(editingModuleId, { title: moduleTitle, description: moduleDescription });
       } else {
-        await postModule(moduleCourseId, { title: moduleTitle, description: moduleDescription })
+        await postModule(moduleCourseId, { title: moduleTitle, description: moduleDescription });
       }
-      setOpenModuleDialog(false)
-      setModuleDescription('')
-      const modulesData = await getModules(moduleCourseId)
-      setCourses(prev =>
-        prev.map(c => (c.id === moduleCourseId ? { ...c, modules: modulesData } : c))
-      )
+      setOpenModuleDialog(false);
+      setModuleDescription('');
+      const modulesData = await getModules(moduleCourseId);
+      setCourses((prev) => prev.map((c) => (c.id === moduleCourseId ? { ...c, modules: modulesData } : c)));
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
   const handleDeleteModule = async (courseId: number, id: number) => {
-    if (!window.confirm('Удалить модуль?')) return
+    if (!window.confirm('Удалить модуль?')) return;
     try {
-      await deleteModule(id)
-      const modulesData = await getModules(courseId)
-      setCourses(prev =>
-        prev.map(c => (c.id === courseId ? { ...c, modules: modulesData } : c))
-      )
+      await deleteModule(id);
+      const modulesData = await getModules(courseId);
+      setCourses((prev) => prev.map((c) => (c.id === courseId ? { ...c, modules: modulesData } : c)));
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
   const handleAddLesson = (courseId: number, moduleId: number) => {
-    setLessonCourseId(courseId)
-    setLessonModuleId(moduleId)
-    setEditingLessonId(null)
-    setLessonTitle('')
-    setLessonContent('')
-    setLessonVideo('')
-    setOpenLessonDialog(true)
-  }
+    setLessonCourseId(courseId);
+    setLessonModuleId(moduleId);
+    setEditingLessonId(null);
+    setLessonTitle('');
+    setLessonContent('');
+    setLessonVideo('');
+    setOpenLessonDialog(true);
+  };
 
   const handleEditLesson = (courseId: number, moduleId: number, lesson: Lesson) => {
-    setLessonCourseId(courseId)
-    setLessonModuleId(moduleId)
-    setEditingLessonId(lesson.id)
-    setLessonTitle(lesson.title)
-    setLessonContent(lesson.content || '')
-    setLessonVideo(lesson.video || '')
-    setOpenLessonDialog(true)
-  }
+    setLessonCourseId(courseId);
+    setLessonModuleId(moduleId);
+    setEditingLessonId(lesson.id);
+    setLessonTitle(lesson.title);
+    setLessonContent(lesson.content || '');
+    setLessonVideo(lesson.video || '');
+    setOpenLessonDialog(true);
+  };
 
   const handleLessonDialogClose = () => {
-    setOpenLessonDialog(false)
-    setEditingLessonId(null)
-    setLessonTitle('')
-    setLessonContent('')
-    setLessonVideo('')
-  }
+    setOpenLessonDialog(false);
+    setEditingLessonId(null);
+    setLessonTitle('');
+    setLessonContent('');
+    setLessonVideo('');
+  };
 
   const saveLesson = async () => {
-    if (!lessonModuleId) return
+    if (!lessonModuleId) return;
     try {
-      const payload = { title: lessonTitle, content: lessonContent, video: lessonVideo }
+      const payload = { title: lessonTitle, content: lessonContent, video: lessonVideo };
       if (editingLessonId) {
-        await putLesson(editingLessonId, payload)
+        await putLesson(editingLessonId, payload);
       } else {
-        await postLesson(lessonModuleId, payload)
+        await postLesson(lessonModuleId, payload);
       }
-      setOpenLessonDialog(false)
-      setLessonVideo('')
-      const lessonsData = await getLessons(lessonModuleId)
-      setCourses(prev =>
-        prev.map(c =>
+      setOpenLessonDialog(false);
+      setLessonVideo('');
+      const lessonsData = await getLessons(lessonModuleId);
+      setCourses((prev) =>
+        prev.map((c) =>
           c.id === lessonCourseId
             ? {
-              ...c,
-              modules: c.modules?.map(m =>
-                m.id === lessonModuleId ? { ...m, lessons: lessonsData } : m
-              )
-            }
+                ...c,
+                modules: c.modules?.map((m) => (m.id === lessonModuleId ? { ...m, lessons: lessonsData } : m))
+              }
             : c
         )
-      )
+      );
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
   const handleDeleteLesson = async (courseId: number, moduleId: number, id: number) => {
-    if (!window.confirm('Удалить урок?')) return
+    if (!window.confirm('Удалить урок?')) return;
     try {
-      await deleteLesson(id)
-      const lessonsData = await getLessons(moduleId)
-      setCourses(prev =>
-        prev.map(c =>
+      await deleteLesson(id);
+      const lessonsData = await getLessons(moduleId);
+      setCourses((prev) =>
+        prev.map((c) =>
           c.id === courseId
             ? {
-              ...c,
-              modules: c.modules?.map(m =>
-                m.id === moduleId ? { ...m, lessons: lessonsData } : m
-              )
-            }
+                ...c,
+                modules: c.modules?.map((m) => (m.id === moduleId ? { ...m, lessons: lessonsData } : m))
+              }
             : c
         )
-      )
+      );
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
   const handleLessonClick = (courseId: number, moduleId: number, lessonId: number) => {
-    setSelectedCourseId(courseId)
-    setSelectedModuleId(moduleId)
-    setSelectedLessonId(lessonId)
-  }
+    setSelectedCourseId(courseId);
+    setSelectedModuleId(moduleId);
+    setSelectedLessonId(lessonId);
+  };
 
   const handleLessonChange = (courseId: number, moduleId: number, lessonId: number) => {
-    setSelectedCourseId(courseId)
-    setSelectedModuleId(moduleId)
-    setSelectedLessonId(lessonId)
-  }
+    setSelectedCourseId(courseId);
+    setSelectedModuleId(moduleId);
+    setSelectedLessonId(lessonId);
+  };
 
   const handleLessonComplete = async (lessonId: number, courseId: number) => {
     try {
-      await completeLesson(lessonId)
+      await completeLesson(lessonId);
       if (courseId === selectedCourseId) {
-        await loadCourses()
+        await loadCourses();
       }
     } catch (e) {
-      console.error(e)
+      console.error(e);
     }
-  }
+  };
 
-  const selectedCourse = courses.find(c => c.id === selectedCourseId)
-  const selectedModule = selectedCourse?.modules?.find(m => m.id === selectedModuleId)
+  const selectedCourse = courses.find((c) => c.id === selectedCourseId);
+  const selectedModule = selectedCourse?.modules?.find((m) => m.id === selectedModuleId);
 
   return (
-    <Box sx={{
-      flexGrow: 1,
-      background: '#edf7ff',
-      minHeight: '100vh'
-    }}>
+    <Box
+      sx={{
+        flexGrow: 1,
+        background: '#edf7ff',
+        minHeight: '100vh'
+      }}
+    >
       <Box sx={{ maxWidth: 1400, mx: 'auto' }}>
-        <Card sx={{
-          mb: 3,
-          background: ' #667eea',
-          color: 'white',
-          borderRadius: 3,
-          boxShadow: '0 8px 32px rgba(0,0,0,0.1)'
-        }}>
+        <Card
+          sx={{
+            mb: 3,
+            background: ' #667eea',
+            color: 'white',
+            borderRadius: 3,
+            boxShadow: '0 8px 32px rgba(0,0,0,0.1)'
+          }}
+        >
           <CardContent sx={{ p: 4 }}>
-            <Box sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              flexWrap: 'wrap',
-              gap: 2
-            }}>
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                flexWrap: 'wrap',
+                gap: 2
+              }}
+            >
               <Box>
-                <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>Курсы</Typography>
+                <Typography variant="h4" sx={{ fontWeight: 700, mb: 1 }}>
+                  Курсы
+                </Typography>
                 <Chip label={`${courses.length} курсов`} sx={{ background: 'rgba(255,255,255,0.2)', color: 'white', fontWeight: 600 }} />
               </Box>
               <Box sx={roleCode !== 'admin' ? { display: 'none' } : {}}>
@@ -484,174 +512,202 @@ const CoursesPage = () => {
         </Card>
 
         <Grid container spacing={2}>
-        <Grid item xs={5}>
-          <MainCard>
-            <List>
-              {courses.map(course => (
-                <React.Fragment key={course.id}>
-                  <ListItem
-                    secondaryAction={
-                      roleCode === 'admin' && (
-                        <>
-                          <IconButton edge="end" color="success" onClick={() => handleAddModule(course.id)}><AddIcon style={{ width: 15, height: 15}} /></IconButton>
-                          <IconButton edge="end" color="primary" onClick={() => handleCreateTestForCourse(course.id)}><LibraryBooksIcon style={{ width: 15, height: 15}} /></IconButton>
-                          <IconButton edge="end" onClick={() => handleEditCourse(course)}><EditIcon style={{ width: 15, height: 15}} /></IconButton>
-                          <IconButton edge="end" color="error" onClick={() => handleDeleteCourse(course.id)}><DeleteIcon style={{ width: 15, height: 15}} /></IconButton>
-                        </>
-                      )
-                    }
-                    disablePadding
-                  >
-                    <ListItemButton onClick={() => toggleCourse(course.id)} sx={{ py: 2 }}>
-                      <ListItemIcon sx={{ minWidth: 28 }}>{course.open ? <ExpandLess /> : <ExpandMore />}</ListItemIcon>
-                      <ListItemText primary={course.title} />
-                    </ListItemButton>
-                  </ListItem>
-                  <Collapse in={course.open && (roleCode === 'admin' || course.hasAccess)} timeout="auto" unmountOnExit>
-                    {roleCode !== 'admin' && !course.hasAccess ? (
-                      <Box sx={{ p: 2 }}>
-                        <Typography variant="body2">Доступ к курсу закрыт</Typography>
-                      </Box>
-                    ) : (
-                    <List component="div" disablePadding sx={{ pl: 4 }}>
-                      {course.modules?.map(mod => (
-                        <React.Fragment key={mod.id}>
-                          <ListItem
-                            secondaryAction={
-                              roleCode === 'admin' && (
-                                <>
-                                <IconButton edge="end" color="success" onClick={() => handleAddLesson(course.id, mod.id)}><AddIcon style={{ width: 15, height: 15}} /></IconButton>
-                                <IconButton edge="end" color="primary" onClick={() => handleCreateTestForModule(course.id, mod.id)}><LibraryBooksIcon style={{ width: 15, height: 15}} /></IconButton>
-                                <IconButton edge="end" onClick={() => handleEditModule(course.id, mod)}><EditIcon style={{ width: 15, height: 15}} /></IconButton>
-                                <IconButton edge="end" color="error" onClick={() => handleDeleteModule(course.id, mod.id)}><DeleteIcon style={{ width: 15, height: 15}} /></IconButton>
-
-                                </>
-                              )
-                            }
-                            disablePadding
-                          >
-                            <ListItemButton onClick={() => toggleModule(course.id, mod.id)} sx={{ pl: 2 }}>
-                              <ListItemIcon sx={{ minWidth: 28 }}>{mod.open ? <ExpandLess /> : <ExpandMore />}</ListItemIcon>
-                              <ListItemText primary={mod.title} />
-                            </ListItemButton>
-                          </ListItem>
-                          <Collapse in={mod.open} timeout="auto" unmountOnExit>
-                            <List component="div" disablePadding sx={{ pl: 4 }}>
-                              {mod.lessons?.map(lesson => (
-                                <ListItem
-                                  key={lesson.id}
-                                  secondaryAction={
-                                    roleCode === 'admin' && (
-                                      <>
-                                        <IconButton edge="end" onClick={() => handleEditLesson(course.id, mod.id, lesson)}><EditIcon style={{ width: 15, height: 15}} /></IconButton>
-                                        <IconButton edge="end" color="error" onClick={() => handleDeleteLesson(course.id, mod.id, lesson.id)}><DeleteIcon style={{ width: 15, height: 15}} /></IconButton>
-                                      </>
-                                    )
-                                  }
-                                  disablePadding
-                                >
-                                  <ListItemButton sx={{ pl: 4 }} onClick={() => handleLessonClick(course.id, mod.id, lesson.id)}>
-                                    <ListItemText primary={lesson.title} />
-                                  </ListItemButton>
-                                </ListItem>
-                              ))}
-                            </List>
-                          </Collapse>
-                        </React.Fragment>
-                      ))}
-                    </List>
-                    )}
-                  </Collapse>
-                </React.Fragment>
-              ))}
-            </List>
-          </MainCard>
+          <Grid item xs={5}>
+            <MainCard>
+              <List>
+                {courses.map((course) => (
+                  <React.Fragment key={course.id}>
+                    <ListItem
+                      secondaryAction={
+                        roleCode === 'admin' && (
+                          <>
+                            <IconButton edge="end" color="success" onClick={() => handleAddModule(course.id)}>
+                              <AddIcon style={{ width: 15, height: 15 }} />
+                            </IconButton>
+                            <IconButton edge="end" color="primary" onClick={() => handleCreateTestForCourse(course.id)}>
+                              <LibraryBooksIcon style={{ width: 15, height: 15 }} />
+                            </IconButton>
+                            <IconButton edge="end" onClick={() => handleEditCourse(course)}>
+                              <EditIcon style={{ width: 15, height: 15 }} />
+                            </IconButton>
+                            <IconButton edge="end" color="error" onClick={() => handleDeleteCourse(course.id)}>
+                              <DeleteIcon style={{ width: 15, height: 15 }} />
+                            </IconButton>
+                          </>
+                        )
+                      }
+                      disablePadding
+                    >
+                      <ListItemButton onClick={() => toggleCourse(course.id)} sx={{ py: 2 }}>
+                        <ListItemIcon sx={{ minWidth: 28 }}>{course.open ? <ExpandLess /> : <ExpandMore />}</ListItemIcon>
+                        <ListItemText primary={course.title} />
+                      </ListItemButton>
+                    </ListItem>
+                    <Collapse in={course.open && (roleCode === 'admin' || course.hasAccess)} timeout="auto" unmountOnExit>
+                      {roleCode !== 'admin' && !course.hasAccess ? (
+                        <Box sx={{ p: 2 }}>
+                          <Typography variant="body2">Доступ к курсу закрыт</Typography>
+                        </Box>
+                      ) : (
+                        <List component="div" disablePadding sx={{ pl: 4 }}>
+                          {course.modules?.map((mod) => (
+                            <React.Fragment key={mod.id}>
+                              <ListItem
+                                secondaryAction={
+                                  roleCode === 'admin' && (
+                                    <>
+                                      <IconButton edge="end" color="success" onClick={() => handleAddLesson(course.id, mod.id)}>
+                                        <AddIcon style={{ width: 15, height: 15 }} />
+                                      </IconButton>
+                                      <IconButton edge="end" color="primary" onClick={() => handleCreateTestForModule(course.id, mod.id)}>
+                                        <LibraryBooksIcon style={{ width: 15, height: 15 }} />
+                                      </IconButton>
+                                      <IconButton edge="end" onClick={() => handleEditModule(course.id, mod)}>
+                                        <EditIcon style={{ width: 15, height: 15 }} />
+                                      </IconButton>
+                                      <IconButton edge="end" color="error" onClick={() => handleDeleteModule(course.id, mod.id)}>
+                                        <DeleteIcon style={{ width: 15, height: 15 }} />
+                                      </IconButton>
+                                    </>
+                                  )
+                                }
+                                disablePadding
+                              >
+                                <ListItemButton onClick={() => toggleModule(course.id, mod.id)} sx={{ pl: 2 }}>
+                                  <ListItemIcon sx={{ minWidth: 28 }}>{mod.open ? <ExpandLess /> : <ExpandMore />}</ListItemIcon>
+                                  <ListItemText primary={mod.title} />
+                                </ListItemButton>
+                              </ListItem>
+                              <Collapse in={mod.open} timeout="auto" unmountOnExit>
+                                <List component="div" disablePadding sx={{ pl: 4 }}>
+                                  {mod.lessons?.map((lesson) => (
+                                    <ListItem
+                                      key={lesson.id}
+                                      secondaryAction={
+                                        roleCode === 'admin' && (
+                                          <>
+                                            <IconButton edge="end" onClick={() => handleEditLesson(course.id, mod.id, lesson)}>
+                                              <EditIcon style={{ width: 15, height: 15 }} />
+                                            </IconButton>
+                                            <IconButton
+                                              edge="end"
+                                              color="error"
+                                              onClick={() => handleDeleteLesson(course.id, mod.id, lesson.id)}
+                                            >
+                                              <DeleteIcon style={{ width: 15, height: 15 }} />
+                                            </IconButton>
+                                          </>
+                                        )
+                                      }
+                                      disablePadding
+                                    >
+                                      <ListItemButton sx={{ pl: 4 }} onClick={() => handleLessonClick(course.id, mod.id, lesson.id)}>
+                                        <ListItemText primary={lesson.title} />
+                                      </ListItemButton>
+                                    </ListItem>
+                                  ))}
+                                </List>
+                              </Collapse>
+                            </React.Fragment>
+                          ))}
+                        </List>
+                      )}
+                    </Collapse>
+                  </React.Fragment>
+                ))}
+              </List>
+            </MainCard>
+          </Grid>
+          <Grid item xs={7}>
+            <MainCard>
+              {selectedLessonId ? (
+                <LessonViewPage
+                  courseId={selectedCourseId}
+                  moduleId={selectedModuleId}
+                  lessonId={selectedLessonId}
+                  onLessonChange={handleLessonChange}
+                  onLessonComplete={handleLessonComplete}
+                />
+              ) : selectedModuleId ? (
+                <Box>
+                  <Typography variant="h4" sx={{ mb: 2 }}>
+                    {selectedModule?.title}
+                  </Typography>
+                  <Typography sx={{ whiteSpace: 'pre-line' }}>{selectedModule?.description}</Typography>
+                </Box>
+              ) : selectedCourseId ? (
+                <Box>
+                  <Typography variant="h4" sx={{ mb: 2 }}>
+                    {selectedCourse?.title}
+                  </Typography>
+                  <Typography sx={{ whiteSpace: 'pre-line', mb: 1 }}>{selectedCourse?.description}</Typography>
+                  {roleCode !== 'admin' && !selectedCourse?.hasAccess && (
+                    <Button variant="contained" onClick={() => handleEnrollCourse(selectedCourseId!)}>
+                      Записаться
+                    </Button>
+                  )}
+                  {selectedCourse?.hasAccess && (
+                    <Box sx={{ mt: 1 }}>
+                      <Typography variant="body2">Прогресс: {selectedCourse?.progress ?? 0}%</Typography>
+                      {roleCode !== 'admin' && selectedCourse?.progress === 100 && (
+                        <Button variant="contained" sx={{ mt: 1 }} onClick={() => navigate(`/start_test/${selectedCourse?.id}`)}>
+                          Пройти тест
+                        </Button>
+                      )}
+                    </Box>
+                  )}
+                </Box>
+              ) : (
+                <Typography variant="h6" color="text.secondary">
+                  Выберите элемент
+                </Typography>
+              )}
+            </MainCard>
+          </Grid>
         </Grid>
-        <Grid item xs={7}>
-          <MainCard>
-            {selectedLessonId ? (
-              <LessonViewPage
-                courseId={selectedCourseId}
-                moduleId={selectedModuleId}
-                lessonId={selectedLessonId}
-                onLessonChange={handleLessonChange}
-                onLessonComplete={handleLessonComplete}
+
+        <CourseFormDialog open={openCourseDialog} onClose={() => setOpenCourseDialog(false)} onSave={saveCourse} course={courseFormData} />
+        <Dialog open={openModuleDialog} onClose={() => setOpenModuleDialog(false)}>
+          <DialogTitle>{editingModuleId ? 'Редактировать модуль' : 'Новый модуль'}</DialogTitle>
+          <DialogContent>
+            <Stack spacing={2} sx={{ mt: 1 }}>
+              <TextField fullWidth label="Название" value={moduleTitle} onChange={(e) => setModuleTitle(e.target.value)} />
+              <TextField
+                fullWidth
+                label="Описание"
+                multiline
+                minRows={3}
+                value={moduleDescription}
+                onChange={(e) => setModuleDescription(e.target.value)}
               />
-            ) : selectedModuleId ? (
-              <Box>
-                <Typography variant="h4" sx={{ mb: 2 }}>{selectedModule?.title}</Typography>
-                <Typography sx={{ whiteSpace: 'pre-line' }}>{selectedModule?.description}</Typography>
-              </Box>
-            ) : selectedCourseId ? (
-              <Box>
-                <Typography variant="h4" sx={{ mb: 2 }}>{selectedCourse?.title}</Typography>
-                <Typography sx={{ whiteSpace: 'pre-line', mb: 1 }}>{selectedCourse?.description}</Typography>
-                {roleCode !== 'admin' && !selectedCourse?.hasAccess && (
-                  <Button variant="contained" onClick={() => handleEnrollCourse(selectedCourseId!)}>
-                    Записаться
-                  </Button>
-                )}
-                {selectedCourse?.hasAccess && (
-                  <Box sx={{ mt: 1 }}>
-                    <Typography variant="body2">Прогресс: {selectedCourse?.progress ?? 0}%</Typography>
-                    {roleCode !== 'admin' && selectedCourse?.progress === 100 && (
-                      <Button variant="contained" sx={{ mt: 1 }} onClick={() => navigate(`/start_test/${selectedCourse?.id}`)}>
-                        Пройти тест
-                      </Button>
-                    )}
-                  </Box>
-                )}
-              </Box>
-            ) : (
-              <Typography variant="h6" color="text.secondary">Выберите элемент</Typography>
-            )}
-          </MainCard>
-        </Grid>
-      </Grid>
-
-      <Dialog open={openCourseDialog} onClose={() => setOpenCourseDialog(false)}>
-        <DialogTitle>{editingCourseId ? 'Редактировать курс' : 'Новый курс'}</DialogTitle>
-      <DialogContent>
-          <Stack spacing={2} sx={{ mt: 1 }}>
-            <TextField fullWidth label="Название" value={courseTitle} onChange={e => setCourseTitle(e.target.value)} />
-            <TextField fullWidth label="Описание" multiline minRows={3} value={courseDescription} onChange={e => setCourseDescription(e.target.value)} />
-          </Stack>
-      </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setOpenCourseDialog(false)}>Отмена</Button>
-          <Button onClick={saveCourse} variant="contained" color="success">Сохранить</Button>
-        </DialogActions>
-      </Dialog>
-      <Dialog open={openModuleDialog} onClose={() => setOpenModuleDialog(false)}>
-        <DialogTitle>{editingModuleId ? 'Редактировать модуль' : 'Новый модуль'}</DialogTitle>
-      <DialogContent>
-          <Stack spacing={2} sx={{ mt: 1 }}>
-            <TextField fullWidth label="Название" value={moduleTitle} onChange={e => setModuleTitle(e.target.value)} />
-            <TextField fullWidth label="Описание" multiline minRows={3} value={moduleDescription} onChange={e => setModuleDescription(e.target.value)} />
-          </Stack>
-      </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setOpenModuleDialog(false)}>Отмена</Button>
-          <Button onClick={saveModule} variant="contained" color="success">Сохранить</Button>
-        </DialogActions>
-      </Dialog>
-      <Dialog open={openLessonDialog} onClose={handleLessonDialogClose} maxWidth="md" fullWidth>
-        <DialogTitle>{editingLessonId ? 'Редактировать урок' : 'Новый урок'}</DialogTitle>
-        <DialogContent dividers>
-          <Stack spacing={2}>
-            <TextField label="Название" value={lessonTitle} onChange={e => setLessonTitle(e.target.value)} />
-            <TextField label="Ссылка на видео" value={lessonVideo} onChange={e => setLessonVideo(e.target.value)} />
-            <JoditEditor ref={editor} value={lessonContent} onBlur={setLessonContent} />
-          </Stack>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleLessonDialogClose}>Отмена</Button>
-          <Button onClick={saveLesson} variant="contained" color="success">Сохранить</Button>
-        </DialogActions>
-      </Dialog>
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setOpenModuleDialog(false)}>Отмена</Button>
+            <Button onClick={saveModule} variant="contained" color="success">
+              Сохранить
+            </Button>
+          </DialogActions>
+        </Dialog>
+        <Dialog open={openLessonDialog} onClose={handleLessonDialogClose} maxWidth="md" fullWidth>
+          <DialogTitle>{editingLessonId ? 'Редактировать урок' : 'Новый урок'}</DialogTitle>
+          <DialogContent dividers>
+            <Stack spacing={2}>
+              <TextField label="Название" value={lessonTitle} onChange={(e) => setLessonTitle(e.target.value)} />
+              <TextField label="Ссылка на видео" value={lessonVideo} onChange={(e) => setLessonVideo(e.target.value)} />
+              <JoditEditor ref={editor} value={lessonContent} onBlur={setLessonContent} />
+            </Stack>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleLessonDialogClose}>Отмена</Button>
+            <Button onClick={saveLesson} variant="contained" color="success">
+              Сохранить
+            </Button>
+          </DialogActions>
+        </Dialog>
       </Box>
     </Box>
-  )
-}
+  );
+};
 
-export default CoursesPage
+export default CoursesPage;


### PR DESCRIPTION
## Summary
- add a CourseFormDialog component
- use CourseFormDialog in `CoursesPage`
- support creating modules and lessons while creating or editing a course

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857eb80819883228fc7a457271534e2