### PR TITLE
Fix PostCSS config resolution

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};


### PR DESCRIPTION
## Summary
- rename `postcss.config.js` to `postcss.config.cjs` so PostCSS loads correctly with CommonJS syntax

## Testing
- `npm start`
- `npm run lint` *(fails: parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a4276f6fc8322bb76e9899688fe81