### PR TITLE
Add image upload for courses/lessons

### DIFF
--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -119,7 +119,7 @@ const CoursesPage = () => {
                   </div>
                 </div>
                 <Button
-                  className="mt-auto w-full bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300"
+                  className="mt-auto w-full bg-green-600 hover:bg-green-700 text-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300"
                   onClick={() => navigate(`/courses/${course.id}/modules`)}
                 >
                   <Play className="h-4 w-4 mr-2" />

--- a/src/pages/lessons-page/LessonViewPage.tsx
+++ b/src/pages/lessons-page/LessonViewPage.tsx
@@ -11,6 +11,7 @@ interface Lesson {
   title: string;
   content: string;
   video?: string;
+  image?: string;
 }
 
 const LessonViewPage = () => {
@@ -54,6 +55,7 @@ const LessonViewPage = () => {
           <ArrowLeft className="h-4 w-4 mr-2" /> К урокам
         </Button>
         <h1 className="text-3xl font-bold text-gray-800 mb-6">{lesson.title}</h1>
+        {lesson.image && <img src={lesson.image} alt={lesson.title} className="mb-4 w-full max-h-96 object-cover" />}
         {lesson.video && <VideoPlayer videoUrl={lesson.video} title={lesson.title} />}
         <Card className="bg-white/80 backdrop-blur-sm border-0 shadow-lg mt-6">
           <CardHeader>

--- a/src/pages/lessons-page/LessonsPage.tsx
+++ b/src/pages/lessons-page/LessonsPage.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/ca
 interface Lesson {
   id: number;
   title: string;
+  image?: string;
 }
 
 const LessonsPage = () => {
@@ -38,11 +39,12 @@ const LessonsPage = () => {
           {lessons.map((lesson) => (
             <Card key={lesson.id} className="bg-white/80 backdrop-blur-sm border-0 shadow-lg">
               <CardHeader>
+                {lesson.image && <img src={lesson.image} alt={lesson.title} className="w-full h-48 object-cover rounded-t" />}
                 <CardTitle className="text-xl font-semibold text-gray-800">{lesson.title}</CardTitle>
               </CardHeader>
               <CardContent>
                 <Button
-                  className="w-full bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white"
+                  className="w-full bg-green-600 hover:bg-green-700 text-white"
                   onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}`)}
                 >
                   <Play className="h-4 w-4 mr-2" /> Начать урок

--- a/src/pages/modules-page/ModulesPage.tsx
+++ b/src/pages/modules-page/ModulesPage.tsx
@@ -68,7 +68,7 @@ const ModulesPage = () => {
                     <span className="text-gray-800">{lesson.title}</span>
                     <Button
                       size="sm"
-                      className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white"
+                      className="bg-green-600 hover:bg-green-700 text-white"
                       onClick={() => navigate(`/courses/${courseId}/modules/${m.id}/lessons/${lesson.id}`)}
                     >
                       <Play className="h-4 w-4 mr-1" /> Начать


### PR DESCRIPTION
## Summary
- support course and lesson image fields in form dialog
- allow uploading course image
- upload images for lessons
- display lesson images and update start buttons color
- show uploaded images on lesson view
- use same green color buttons like tests

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_685a5264a98c8322b779bdb2e8fba6c3