### PR TITLE
Update lesson forms and course images

### DIFF
--- a/src/components/CourseFormDialog.tsx
+++ b/src/components/CourseFormDialog.tsx
@@ -70,7 +70,13 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
       setAccessType(course.accessType);
       setAccessId(course.accessId || '');
       setModules(course.modules.length ? course.modules : [emptyModule()]);
-      setCourseImage(course.image || '');
+      if (course.image) {
+        setCourseImage(course.image);
+      } else if (course.imageId) {
+        setCourseImage(`${import.meta.env.VITE_REACT_APP_API_URL}/api/files/${course.imageId}`);
+      } else {
+        setCourseImage('');
+      }
       setCourseImageId(course.imageId || null);
     } else if (open) {
       setTitle('');
@@ -249,12 +255,6 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
                       <DeleteIcon />
                     </IconButton>
                   </Stack>
-                  <TextField
-                    label="Ссылка на видео"
-                    value={les.video}
-                    onChange={(e) => handleLessonChange(modIndex, lesIndex, 'video', e.target.value)}
-                    fullWidth
-                  />
                   <TextField
                     label="Содержание"
                     multiline

--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -34,6 +34,7 @@ interface Course {
   title: string;
   description: string;
   image?: string;
+  img_id?: number;
   duration?: string;
   students?: number;
   rating?: number;
@@ -174,7 +175,15 @@ const CoursesPage = () => {
               style={{ animationDelay: `${index * 0.1}s` }}
             >
               <div className="relative">
-                <img src={course.image || 'https://via.placeholder.com/400x200'} alt={course.title} className="w-full h-48 object-cover" />
+                <img
+                  src={
+                    course.img_id
+                      ? `${import.meta.env.VITE_REACT_APP_API_URL}/api/files/${course.img_id}`
+                      : course.image || 'https://via.placeholder.com/400x200'
+                  }
+                  alt={course.title}
+                  className="w-full h-48 object-cover"
+                />
                 {course.category && (
                   <div className="absolute top-4 left-4">
                     <Badge className="bg-gradient-to-r from-purple-600 to-blue-600 text-white">{course.category}</Badge>

--- a/src/pages/courses-page/CoursesPage_old.tsx
+++ b/src/pages/courses-page/CoursesPage_old.tsx
@@ -773,7 +773,6 @@ const CoursesPage = () => {
           <DialogContent dividers>
             <Stack spacing={2}>
               <TextField label="Название" value={lessonTitle} onChange={(e) => setLessonTitle(e.target.value)} />
-              <TextField label="Ссылка на видео" value={lessonVideo} onChange={(e) => setLessonVideo(e.target.value)} />
               <JoditEditor ref={editor} value={lessonContent} onBlur={setLessonContent} />
             </Stack>
           </DialogContent>


### PR DESCRIPTION
## Summary
- display course cards with images loaded by `img_id`
- support showing uploaded image when editing a course
- remove video link field from lesson forms

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685bccf394dc8322a743ed30467512d7