### PR TITLE
Fix course image display

### DIFF
--- a/src/components/CourseFormDialog.tsx
+++ b/src/components/CourseFormDialog.tsx
@@ -71,9 +71,10 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
       setAccessId(course.accessId || '');
       setModules(course.modules.length ? course.modules : [emptyModule()]);
       if (course.image) {
-        setCourseImage(course.image);
+        const img = typeof course.image === 'string' ? course.image : (course.image as any).path;
+        setCourseImage(img || '');
       } else if (course.imageId) {
-        setCourseImage(`${import.meta.env.VITE_REACT_APP_API_URL}/api/files/${course.imageId}`);
+        setCourseImage('');
       } else {
         setCourseImage('');
       }

--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -33,7 +33,7 @@ interface Course {
   id: number;
   title: string;
   description: string;
-  image?: string;
+  image?: { path?: string } | string | null;
   img_id?: number;
   duration?: string;
   students?: number;
@@ -52,7 +52,14 @@ const CoursesPage = () => {
   const loadCourses = async () => {
     try {
       const data = await getCourses();
-      setCourses(data);
+      const formatted = data.map((c: any) => ({
+        ...c,
+        image:
+          typeof c.image === 'string'
+            ? c.image
+            : c.image?.path || null
+      }));
+      setCourses(formatted);
     } catch (e) {
       console.error(e);
     }
@@ -177,9 +184,9 @@ const CoursesPage = () => {
               <div className="relative">
                 <img
                   src={
-                    course.img_id
-                      ? `${import.meta.env.VITE_REACT_APP_API_URL}/api/files/${course.img_id}`
-                      : course.image || 'https://via.placeholder.com/400x200'
+                    typeof course.image === 'string'
+                      ? course.image
+                      : course.image?.path || 'https://via.placeholder.com/400x200'
                   }
                   alt={course.title}
                   className="w-full h-48 object-cover"


### PR DESCRIPTION
## Summary
- handle image objects for courses
- show course images correctly

## Testing
- `npm run lint` *(fails: Missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_685bd214964c8322bac7c481e87af3dc