### PR TITLE
Add lesson editor and course editor pages

### DIFF
--- a/src/components/CourseFormDialog.tsx
+++ b/src/components/CourseFormDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
+import JoditEditor from 'jodit-react';
 import { postData } from '../api';
 
 interface LessonForm {
@@ -257,13 +258,12 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
                     </IconButton>
                   </Stack>
                   <TextField
-                    label="Содержание"
-                    multiline
-                    minRows={3}
-                    value={les.content}
-                    onChange={(e) => handleLessonChange(modIndex, lesIndex, 'content', e.target.value)}
+                    label="Ссылка на видео"
+                    value={les.video}
+                    onChange={(e) => handleLessonChange(modIndex, lesIndex, 'video', e.target.value)}
                     fullWidth
                   />
+                  <JoditEditor value={les.content || ''} onBlur={(val) => handleLessonChange(modIndex, lesIndex, 'content', val)} />
                 </Stack>
               ))}
               <Button startIcon={<AddIcon />} onClick={() => addLesson(modIndex)}>

--- a/src/components/LessonFormDialog.tsx
+++ b/src/components/LessonFormDialog.tsx
@@ -1,0 +1,101 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button, Stack, IconButton } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import JoditEditor from 'jodit-react';
+import { postData } from '../api';
+
+export interface LessonFormData {
+  id?: number;
+  title: string;
+  content?: string;
+  video?: string;
+  image?: string;
+}
+
+interface LessonFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (data: LessonFormData) => void;
+  lesson?: LessonFormData;
+}
+
+const LessonFormDialog: React.FC<LessonFormDialogProps> = ({ open, onClose, onSave, lesson }) => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [video, setVideo] = useState('');
+  const [image, setImage] = useState<string>('');
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const editor = useRef<any>(null);
+
+  useEffect(() => {
+    if (lesson) {
+      setTitle(lesson.title);
+      setContent(lesson.content || '');
+      setVideo(lesson.video || '');
+      setImage(lesson.image || '');
+    } else if (open) {
+      setTitle('');
+      setContent('');
+      setVideo('');
+      setImage('');
+      setImageFile(null);
+    }
+  }, [lesson, open]);
+
+  const handleUpload = async () => {
+    if (!imageFile) return;
+    const formData = new FormData();
+    formData.append('file', imageFile);
+    try {
+      const res = await postData('uploadLogo', formData);
+      if (res && res.url) {
+        setImage(res.url);
+        setImageFile(null);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleSave = () => {
+    onSave({ id: lesson?.id, title, content, video, image });
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>{lesson ? 'Редактировать урок' : 'Новый урок'}</DialogTitle>
+      <DialogContent dividers>
+        <Stack spacing={2} sx={{ mt: 1 }}>
+          <TextField fullWidth label="Название" value={title} onChange={(e) => setTitle(e.target.value)} />
+          <TextField fullWidth label="Ссылка на видео" value={video} onChange={(e) => setVideo(e.target.value)} />
+          <Stack direction="row" spacing={2} alignItems="center">
+            <Button variant="outlined" component="label" size="small">
+              Картинка
+              <input type="file" hidden accept="image/*" onChange={(e) => setImageFile(e.target.files?.[0] || null)} />
+            </Button>
+            {imageFile && (
+              <Button variant="contained" color="primary" onClick={handleUpload}>
+                Загрузить
+              </Button>
+            )}
+            {image && <img src={image} alt="lesson" style={{ height: 40 }} />}
+            {image && (
+              <IconButton onClick={() => setImage('')} size="small">
+                <DeleteIcon />
+              </IconButton>
+            )}
+          </Stack>
+          <JoditEditor ref={editor} value={content} onBlur={(newContent) => setContent(newContent)} />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Отмена</Button>
+        <Button onClick={handleSave} variant="contained" color="success">
+          Сохранить
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default LessonFormDialog;

--- a/src/pages/course-editor-page/CourseEditorPage.tsx
+++ b/src/pages/course-editor-page/CourseEditorPage.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import CourseFormDialog, { CourseFormData } from '../../components/CourseFormDialog';
+import { getModules, getLessons, getCourse, postCourse, putCourse, postModule, putModule, postLesson, putLesson } from '../../api';
+
+const CourseEditorPage = () => {
+  const { courseId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [initialData, setInitialData] = useState<CourseFormData | undefined>(undefined);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (location.state && (location.state as any).course) {
+      setInitialData((location.state as any).course);
+      if (courseId) setEditingId(Number(courseId));
+      return;
+    }
+    if (!courseId) return;
+    (async () => {
+      try {
+        const c = await getCourse(Number(courseId));
+        const modulesData = await getModules(Number(courseId));
+        const modulesWithLessons = await Promise.all(
+          modulesData.map(async (m: any) => {
+            const lessonsData = await getLessons(m.id);
+            return { ...m, lessons: lessonsData };
+          })
+        );
+        const formData: CourseFormData = {
+          title: c.title,
+          description: c.description || '',
+          accessType: 'public',
+          modules: modulesWithLessons.map((m: any) => ({
+            id: m.id,
+            title: m.title,
+            description: m.description || '',
+            lessons:
+              m.lessons?.map((l: any) => ({
+                id: l.id,
+                title: l.title,
+                content: l.content || '',
+                video: l.video || '',
+                image: l.image || ''
+              })) || []
+          }))
+        };
+        setInitialData(formData);
+        setEditingId(Number(courseId));
+      } catch (e) {
+        console.error(e);
+      }
+    })();
+  }, [courseId]);
+
+  const handleSave = async (data: CourseFormData) => {
+    try {
+      let id = editingId;
+      if (editingId) {
+        await putCourse(editingId, { title: data.title, description: data.description, img_id: data.imageId });
+      } else {
+        const res = await postCourse({
+          title: data.title,
+          description: data.description,
+          accessType: data.accessType,
+          accessId: data.accessId,
+          img_id: data.imageId,
+          image: data.image
+        });
+        id = res?.id;
+      }
+      if (id) {
+        for (const mod of data.modules) {
+          let modId = mod.id;
+          if (modId) {
+            await putModule(modId, { title: mod.title, description: mod.description });
+          } else {
+            const m = await postModule(id, { title: mod.title, description: mod.description });
+            modId = m?.id;
+          }
+          if (modId) {
+            for (const les of mod.lessons) {
+              if (les.id) {
+                await putLesson(les.id, { title: les.title, content: les.content, video: les.video, image: les.image });
+              } else {
+                await postLesson(modId, { title: les.title, content: les.content, video: les.video, image: les.image });
+              }
+            }
+          }
+        }
+      }
+      navigate('/courses');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return <CourseFormDialog open onClose={() => navigate('/courses')} onSave={handleSave} course={initialData} />;
+};
+
+export default CourseEditorPage;

--- a/src/pages/modules-page/ModulesPage.tsx
+++ b/src/pages/modules-page/ModulesPage.tsx
@@ -1,24 +1,20 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { ArrowLeft, Play } from 'lucide-react';
-import { getModules, getLessons, postModule, postLesson, getCourse } from 'api';
+import { getModules, getLessons, postModule, postLesson, putLesson, getCourse } from 'api';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Context } from '../..';
-import {
-  Card as MuiCard,
-  CardContent as MuiCardContent,
-  Typography,
-  Box,
-  Chip,
-  Stack,
-  Button as MuiButton
-} from '@mui/material';
+import { Card as MuiCard, CardContent as MuiCardContent, Typography, Box, Chip, Stack, Button as MuiButton } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+import LessonFormDialog, { LessonFormData } from '../../components/LessonFormDialog';
 
 interface Lesson {
   id: number;
   title: string;
+  content?: string;
+  video?: string;
+  image?: string;
 }
 
 interface Module {
@@ -43,20 +39,20 @@ const ModulesPage = () => {
   const { authStore } = useContext(Context);
   const { roleCode } = authStore;
 
+  const [openLessonDialog, setOpenLessonDialog] = useState(false);
+  const [currentModuleId, setCurrentModuleId] = useState<number | null>(null);
+  const [editingLesson, setEditingLesson] = useState<LessonFormData | undefined>(undefined);
+
   const loadModules = async () => {
     if (!courseId) return;
     try {
       const m = await getModules(Number(courseId));
-      const modulesArray = Array.isArray(m)
-        ? m
-        : (m.modules || m.items || []);
+      const modulesArray = Array.isArray(m) ? m : m.modules || m.items || [];
       const withLessons = await Promise.all(
         modulesArray.map(async (mod: any) => {
           try {
             const lessonsData = await getLessons(mod.id);
-            const lessonsArray = Array.isArray(lessonsData)
-              ? lessonsData
-              : lessonsData.lessons || lessonsData.items || [];
+            const lessonsArray = Array.isArray(lessonsData) ? lessonsData : lessonsData.lessons || lessonsData.items || [];
             return { ...mod, lessons: lessonsArray };
           } catch (e) {
             console.error(e);
@@ -74,8 +70,7 @@ const ModulesPage = () => {
     if (!courseId) return;
     try {
       const c = await getCourse(Number(courseId));
-      const image =
-        typeof c.image === 'string' ? c.image : c.image?.path || null;
+      const image = typeof c.image === 'string' ? c.image : c.image?.path || null;
       setCourse({ ...c, image });
     } catch (e) {
       console.error(e);
@@ -102,11 +97,34 @@ const ModulesPage = () => {
     }
   };
 
-  const handleAddLesson = async (moduleId: number) => {
-    const title = window.prompt('Название урока');
-    if (!title) return;
+  const handleAddLesson = (moduleId: number) => {
+    setCurrentModuleId(moduleId);
+    setEditingLesson(undefined);
+    setOpenLessonDialog(true);
+  };
+
+  const handleEditLesson = (moduleId: number, lesson: Lesson) => {
+    setCurrentModuleId(moduleId);
+    setEditingLesson({
+      id: lesson.id,
+      title: lesson.title,
+      content: (lesson as any).content || '',
+      video: (lesson as any).video || '',
+      image: (lesson as any).image
+    });
+    setOpenLessonDialog(true);
+  };
+
+  const saveLesson = async (data: LessonFormData) => {
+    if (!currentModuleId) return;
     try {
-      await postLesson(moduleId, { title });
+      if (data.id) {
+        await putLesson(data.id, { title: data.title, content: data.content, video: data.video, image: data.image });
+      } else {
+        await postLesson(currentModuleId, { title: data.title, content: data.content, video: data.video, image: data.image });
+      }
+      setOpenLessonDialog(false);
+      setEditingLesson(undefined);
       await loadModules();
     } catch (e) {
       console.error(e);
@@ -114,91 +132,98 @@ const ModulesPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
-      <div className="container mx-auto px-4 py-8">
-        <Box sx={{ maxWidth: 1400, mx: 'auto' }}>
-          <MuiCard sx={{ mb: 3, background: '#667eea', color: 'white', borderRadius: 3, boxShadow: '0 8px 32px rgba(0,0,0,0.1)' }}>
-            <MuiCardContent sx={{ p: 4 }}>
-              {course?.image && (
-                <img
-                  src={course.image as string}
-                  alt={course.title}
-                  style={{ width: '100%', maxHeight: 200, objectFit: 'cover', marginBottom: 16 }}
-                />
-              )}
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 2 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                  <Button variant="ghost" size="sm" className="hover:bg-white/50" onClick={() => navigate(-1)}>
-                    <ArrowLeft className="h-4 w-4 mr-2" /> Назад
-                  </Button>
-                  <Typography variant="h4" sx={{ fontWeight: 700 }}>
-                    {course?.title || 'Модули курса'}
-                  </Typography>
+    <>
+      <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+        <div className="container mx-auto px-4 py-8">
+          <Box sx={{ maxWidth: 1400, mx: 'auto' }}>
+            <MuiCard sx={{ mb: 3, background: '#667eea', color: 'white', borderRadius: 3, boxShadow: '0 8px 32px rgba(0,0,0,0.1)' }}>
+              <MuiCardContent sx={{ p: 4 }}>
+                {course?.image && (
+                  <img
+                    src={course.image as string}
+                    alt={course.title}
+                    style={{ width: '100%', maxHeight: 200, objectFit: 'cover', marginBottom: 16 }}
+                  />
+                )}
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 2 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                    <Button variant="ghost" size="sm" className="hover:bg-white/50" onClick={() => navigate(-1)}>
+                      <ArrowLeft className="h-4 w-4 mr-2" /> Назад
+                    </Button>
+                    <Typography variant="h4" sx={{ fontWeight: 700 }}>
+                      {course?.title || 'Модули курса'}
+                    </Typography>
+                  </Box>
+                  {roleCode === 'admin' && (
+                    <Stack direction="row" spacing={2}>
+                      <MuiButton
+                        variant="contained"
+                        sx={{
+                          textTransform: 'none',
+                          background: 'linear-gradient(45deg, #4caf50, #45a049)',
+                          fontWeight: 600,
+                          boxShadow: '0 4px 15px rgba(76, 175, 80, 0.3)',
+                          '&:hover': {
+                            background: 'linear-gradient(45deg, #45a049, #4caf50)',
+                            transform: 'translateY(-2px)',
+                            boxShadow: '0 6px 20px rgba(76, 175, 80, 0.4)'
+                          }
+                        }}
+                        startIcon={<AddIcon />}
+                        onClick={handleAddModule}
+                      >
+                        Новый модуль
+                      </MuiButton>
+                    </Stack>
+                  )}
                 </Box>
-                {roleCode === 'admin' && (
-                  <Stack direction="row" spacing={2}>
-                    <MuiButton
-                      variant="contained"
-                      sx={{
-                        textTransform: 'none',
-                        background: 'linear-gradient(45deg, #4caf50, #45a049)',
-                        fontWeight: 600,
-                        boxShadow: '0 4px 15px rgba(76, 175, 80, 0.3)',
-                        '&:hover': {
-                          background: 'linear-gradient(45deg, #45a049, #4caf50)',
-                          transform: 'translateY(-2px)',
-                          boxShadow: '0 6px 20px rgba(76, 175, 80, 0.4)'
-                        }
-                      }}
-                      startIcon={<AddIcon />}
-                      onClick={handleAddModule}
+              </MuiCardContent>
+            </MuiCard>
+          </Box>
+          <div className="space-y-4">
+            {modules.length === 0 && <Typography className="text-gray-600">Модули не найдены</Typography>}
+            {modules.map((m) => (
+              <Card key={m.id} className="bg-white/80 backdrop-blur-sm border-0 shadow-lg">
+                <CardHeader>
+                  <CardTitle className="text-xl font-semibold text-gray-800">
+                    Модуль {m.id}: {m.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  {m.lessons.map((lesson) => (
+                    <div
+                      key={lesson.id}
+                      className="flex items-center justify-between p-3 bg-white rounded-lg hover:bg-purple-50 transition-colors"
                     >
-                      Новый модуль
-                    </MuiButton>
-                  </Stack>
-                )}
-              </Box>
-            </MuiCardContent>
-          </MuiCard>
-        </Box>
-        <div className="space-y-4">
-          {modules.length === 0 && (
-            <Typography className="text-gray-600">Модули не найдены</Typography>
-          )}
-          {modules.map((m) => (
-            <Card key={m.id} className="bg-white/80 backdrop-blur-sm border-0 shadow-lg">
-              <CardHeader>
-                <CardTitle className="text-xl font-semibold text-gray-800">
-                  Модуль {m.id}: {m.title}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                {m.lessons.map((lesson) => (
-                  <div
-                    key={lesson.id}
-                    className="flex items-center justify-between p-3 bg-white rounded-lg hover:bg-purple-50 transition-colors"
-                  >
-                    <span className="text-gray-800">{lesson.title}</span>
-                    <Button
-                      size="sm"
-                      className="bg-green-600 hover:bg-green-700 text-white"
-                      onClick={() => navigate(`/courses/${courseId}/modules/${m.id}/lessons/${lesson.id}`)}
-                    >
-                    <Play className="h-4 w-4 mr-1" /> Начать
-                  </Button>
-                </div>
-                ))}
-                {roleCode === 'admin' && (
-                  <Button size="sm" className="bg-blue-600 hover:bg-blue-700 text-white" onClick={() => handleAddLesson(m.id)}>
-                    <AddIcon className="h-4 w-4 mr-1" /> Добавить урок
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          ))}
+                      <span
+                        className="text-gray-800"
+                        onClick={() => roleCode === 'admin' && handleEditLesson(m.id, lesson)}
+                        style={{ cursor: roleCode === 'admin' ? 'pointer' : 'default' }}
+                      >
+                        {lesson.title}
+                      </span>
+                      <Button
+                        size="sm"
+                        className="bg-green-600 hover:bg-green-700 text-white"
+                        onClick={() => navigate(`/courses/${courseId}/modules/${m.id}/lessons/${lesson.id}`)}
+                      >
+                        <Play className="h-4 w-4 mr-1" /> Начать
+                      </Button>
+                    </div>
+                  ))}
+                  {roleCode === 'admin' && (
+                    <Button size="sm" className="bg-blue-600 hover:bg-blue-700 text-white" onClick={() => handleAddLesson(m.id)}>
+                      <AddIcon className="h-4 w-4 mr-1" /> Добавить урок
+                    </Button>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
         </div>
       </div>
-    </div>
+      <LessonFormDialog open={openLessonDialog} onClose={() => setOpenLessonDialog(false)} onSave={saveLesson} lesson={editingLesson} />
+    </>
   );
 };
 

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -1,4 +1,3 @@
-
 import Dashboard from 'layout/Dashboard';
 import MainPage from 'pages/main-page/main-page';
 import ResultsPage from 'pages/results-page/results-page';
@@ -11,11 +10,11 @@ import CoursesPage from 'pages/courses-page/CoursesPage';
 import ModulesPage from 'pages/modules-page/ModulesPage';
 import LessonsPage from 'pages/lessons-page/LessonsPage';
 import LessonViewPage from 'pages/lessons-page/LessonViewPage';
+import CourseEditorPage from 'pages/course-editor-page/CourseEditorPage';
 import TestUserResult from 'components/testUserResult/TestUserResult';
 import CreateRespondentsPage from 'pages/respondents-page/create-respondents-list';
 import AdminPage from 'pages/admin-page/AdminPage';
 import CourseAccessAdminPage from 'pages/course-access-admin/CourseAccessAdminPage';
-
 
 // ==============================|| MAIN ROUTING ||============================== //
 
@@ -23,7 +22,6 @@ const MainRoutes = {
   path: '/',
   element: <Dashboard />,
   children: [
-  
     {
       path: '/',
       children: [
@@ -57,7 +55,7 @@ const MainRoutes = {
         },
         {
           path: '/results',
-          element: <ResultsPage />,
+          element: <ResultsPage />
         },
         {
           path: '/results/:resultId',
@@ -76,7 +74,7 @@ const MainRoutes = {
           element: <SettingsPage />
         },
         {
-          path: '/start_test/:testId',  // динамический параметр testId
+          path: '/start_test/:testId', // динамический параметр testId
           element: <TestPage />
         },
         {
@@ -92,6 +90,14 @@ const MainRoutes = {
           element: <CoursesPage />
         },
         {
+          path: '/courses/new',
+          element: <CourseEditorPage />
+        },
+        {
+          path: '/courses/:courseId/edit',
+          element: <CourseEditorPage />
+        },
+        {
           path: '/courses/:courseId/modules',
           element: <ModulesPage />
         },
@@ -102,9 +108,9 @@ const MainRoutes = {
         {
           path: '/courses/:courseId/modules/:moduleId/lessons/:lessonId',
           element: <LessonViewPage />
-        },
+        }
       ]
-    },
+    }
   ]
 };
 


### PR DESCRIPTION
## Summary
- add `LessonFormDialog` component with rich text and video fields
- support lesson editing in ModulesPage
- create CourseEditorPage for full screen course editing
- update CourseFormDialog to use Jodit editor and video field for lessons
- route buttons to CourseEditorPage from CoursesPage

## Testing
- `npx prettier -w src/components/LessonFormDialog.tsx src/components/CourseFormDialog.tsx src/pages/modules-page/ModulesPage.tsx src/pages/courses-page/CoursesPage.tsx src/pages/course-editor-page/CourseEditorPage.tsx src/routes/MainRoutes.jsx`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685bfe0955f483229af221907233ec06