### PR TITLE
Fix lesson creation in course editor

### DIFF
--- a/src/components/CourseFormDialog.tsx
+++ b/src/components/CourseFormDialog.tsx
@@ -31,7 +31,6 @@ interface LessonForm {
 interface ModuleForm {
   id?: number;
   title: string;
-  description?: string;
   lessons: LessonForm[];
 }
 
@@ -53,7 +52,7 @@ interface CourseFormDialogProps {
 }
 
 const emptyLesson = (): LessonForm => ({ title: '', content: '', video: '' });
-const emptyModule = (): ModuleForm => ({ title: '', description: '', lessons: [emptyLesson()] });
+const emptyModule = (): ModuleForm => ({ title: '', lessons: [] });
 
 const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSave, course }) => {
   const [title, setTitle] = useState('');
@@ -75,7 +74,11 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
       setDescription(course.description || '');
       setAccessType(course.accessType);
       setAccessId(course.accessId || '');
-      setModules(course.modules.length ? course.modules : [emptyModule()]);
+      setModules(
+        course.modules.length
+          ? course.modules.map((m) => ({ id: m.id, title: m.title, lessons: m.lessons || [] }))
+          : [emptyModule()]
+      );
       if (course.image) {
         const img = typeof course.image === 'string' ? course.image : (course.image as any).path;
         setCourseImage(img || '');
@@ -96,10 +99,12 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
     }
   }, [course, open]);
 
-  const handleModuleChange = (index: number, field: keyof ModuleForm, value: string) => {
+  const handleModuleTitleChange = (index: number, value: string) => {
     setModules((prev) => {
       const updated = [...prev];
-      (updated[index] as any)[field] = value;
+      if (updated[index]) {
+        updated[index].title = value;
+      }
       return updated;
     });
   };
@@ -233,20 +238,13 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
                   <TextField
                     label="Название модуля"
                     value={mod.title}
-                    onChange={(e) => handleModuleChange(modIndex, 'title', e.target.value)}
+                    onChange={(e) => handleModuleTitleChange(modIndex, e.target.value)}
                     fullWidth
                   />
                   <IconButton onClick={() => removeModule(modIndex)}>
                     <DeleteIcon />
                   </IconButton>
                 </Stack>
-                <TextField
-                  label="Описание"
-                  multiline
-                  minRows={2}
-                  value={mod.description}
-                  onChange={(e) => handleModuleChange(modIndex, 'description', e.target.value)}
-                />
                 <Typography variant="subtitle1">Уроки</Typography>
                 {mod.lessons.map((les, lesIndex) => (
                   <Stack key={lesIndex} direction="row" spacing={1} alignItems="center">

--- a/src/pages/course-editor-page/CourseEditorPage.tsx
+++ b/src/pages/course-editor-page/CourseEditorPage.tsx
@@ -34,7 +34,6 @@ const CourseEditorPage = () => {
           modules: modulesWithLessons.map((m: any) => ({
             id: m.id,
             title: m.title,
-            description: m.description || '',
             lessons:
               m.lessons?.map((l: any) => ({
                 id: l.id,
@@ -70,16 +69,18 @@ const CourseEditorPage = () => {
         id = res?.id;
       }
       if (id) {
-        for (const mod of data.modules) {
+        const validModules = data.modules.filter((m) => m.title.trim());
+        for (const mod of validModules) {
           let modId = mod.id;
           if (modId) {
-            await putModule(modId, { title: mod.title, description: mod.description });
+            await putModule(modId, { title: mod.title });
           } else {
-            const m = await postModule(id, { title: mod.title, description: mod.description });
+            const m = await postModule(id, { title: mod.title });
             modId = m?.id;
           }
           if (modId) {
-            for (const les of mod.lessons) {
+            const validLessons = (mod.lessons || []).filter((l) => l.title.trim());
+            for (const les of validLessons) {
               if (les.id) {
                 await putLesson(les.id, { title: les.title, content: les.content, video: les.video, image: les.image });
               } else {

--- a/src/pages/modules-page/ModulesPage.tsx
+++ b/src/pages/modules-page/ModulesPage.tsx
@@ -220,7 +220,7 @@ const ModulesPage = () => {
               <Card key={m.id} className="bg-white/80 backdrop-blur-sm border-0 shadow-lg">
                 <CardHeader>
                   <CardTitle className="text-xl font-semibold text-gray-800">
-                    Модуль {m.id}: {m.title}
+                    {m.title}
                   </CardTitle>
                   {roleCode !== 'admin' && (
                     <div className="mt-2">


### PR DESCRIPTION
## Summary
- prevent sending empty modules and lessons when saving a course
- only show the module title when viewing modules
- simplify course module form to omit descriptions and blank lessons

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685cee09abf083228fb1b5066ad5fa11