### PR TITLE
Update lesson start behavior

### DIFF
--- a/src/pages/lessons-page/LessonViewPage.tsx
+++ b/src/pages/lessons-page/LessonViewPage.tsx
@@ -51,7 +51,12 @@ const LessonViewPage = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
       <div className="container mx-auto px-4 py-8">
-        <Button variant="ghost" size="sm" className="mb-4 hover:bg-white/50" onClick={() => navigate(-1)}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mb-4 hover:bg-white/50"
+          onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}`)}
+        >
           <ArrowLeft className="h-4 w-4 mr-2" /> К урокам
         </Button>
         <h1 className="text-3xl font-bold text-gray-800 mb-6">{lesson.title}</h1>

--- a/src/pages/lessons-page/LessonsPage.tsx
+++ b/src/pages/lessons-page/LessonsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, Play } from 'lucide-react';
-import { getLessons, postLesson } from 'api';
+import { getLessons, postLesson, completeLesson } from 'api';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Context } from '../..';
@@ -19,6 +19,7 @@ interface Lesson {
   id: number;
   title: string;
   image?: string;
+  completed?: boolean;
 }
 
 const LessonsPage = () => {
@@ -103,9 +104,16 @@ const LessonsPage = () => {
               <CardContent>
                 <Button
                   className="w-full bg-green-600 hover:bg-green-700 text-white"
-                  onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}`)}
+                  onClick={async () => {
+                    try {
+                      await completeLesson(lesson.id);
+                    } catch (e) {
+                      console.error(e);
+                    }
+                    navigate(`/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}`);
+                  }}
                 >
-                  <Play className="h-4 w-4 mr-2" /> Начать урок
+                  <Play className="h-4 w-4 mr-2" /> {lesson.completed ? 'Повторить' : 'Начать'}
                 </Button>
               </CardContent>
             </Card>

--- a/src/pages/modules-page/ModulesPage.tsx
+++ b/src/pages/modules-page/ModulesPage.tsx
@@ -9,7 +9,8 @@ import {
   putLesson,
   getCourse,
   getModuleProgress,
-  getCourseProgress
+  getCourseProgress,
+  completeLesson
 } from 'api';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
@@ -294,7 +295,14 @@ const ModulesPage = () => {
                       <Button
                         size="sm"
                         className="bg-green-600 hover:bg-green-700 text-white"
-                        onClick={() => navigate(`/courses/${courseId}/modules/${m.id}/lessons/${lesson.id}`)}
+                        onClick={async () => {
+                          try {
+                            await completeLesson(lesson.id);
+                          } catch (e) {
+                            console.error(e);
+                          }
+                          navigate(`/courses/${courseId}/modules/${m.id}/lessons/${lesson.id}`);
+                        }}
                       >
                         <Play className="h-4 w-4 mr-1" /> {completed ? 'Повторить' : 'Начать'}
                       </Button>


### PR DESCRIPTION
## Summary
- revert API utils to previous version
- mark lesson complete when starting from list
- show 'Повторить' if lesson finished
- navigate back to lesson list from lesson view

## Testing
- `yarn lint` *(fails: Parsing errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685e7ef8ca408322b194b2f9d392091d