### PR TITLE
Fix lessons back navigation path

### DIFF
--- a/src/pages/lessons-page/LessonViewPage.tsx
+++ b/src/pages/lessons-page/LessonViewPage.tsx
@@ -55,7 +55,9 @@ const LessonViewPage = () => {
           variant="ghost"
           size="sm"
           className="mb-4 hover:bg-white/50"
-          onClick={() => navigate(`/courses/${courseId}/modules/${moduleId}`)}
+          onClick={() =>
+            navigate(`/courses/${courseId}/modules/${moduleId}/lessons`)
+          }
         >
           <ArrowLeft className="h-4 w-4 mr-2" /> К урокам
         </Button>


### PR DESCRIPTION
## Summary
- fix the path for the "Back to lessons" button in `LessonViewPage`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: couldn't find an eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6862a40676f48322a40ea5d9b38ef0d8