### PR TITLE
Fix closing brace in CourseAccessAdminPage

### DIFF
--- a/src/pages/course-access-admin/CourseAccessAdminPage.tsx
+++ b/src/pages/course-access-admin/CourseAccessAdminPage.tsx
@@ -202,7 +202,7 @@ const CourseAccessAdminPage = observer(() => {
               {c.title}
             </MenuItem>
           );
-        })
+        })}
       </Menu>
     </Box>
   );


### PR DESCRIPTION
## Summary
- fix missing JSX expression brace in `CourseAccessAdminPage`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68637f0f3a0c83228155e8773b11b8c6