### PR TITLE
Fix CoursesPage closing parens

### DIFF
--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -302,7 +302,8 @@ const CoursesPage = () => {
                 </Button>
               </CardContent>
             </Card>
-          ))}
+          );
+        })}
         </div>
         <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)} onClose={handleMenuClose}>
           <MenuItem


### PR DESCRIPTION
## Summary
- fix closing parenthesis for the CoursesPage map

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6863be4f19c883229c64b53726b524aa