### PR TITLE
Implement course access toggling and UI tweaks

### DIFF
--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -249,6 +249,9 @@ export const deleteLesson = (id: number) => deleteData('lessonById', {}, id);
 export const enrollCourse = (courseId: number) => postData('enrollCourse', {}, courseId);
 export const enrollCourseAdmin = (courseId: number, userId: number) =>
   postData('enrollCourseAdmin', {}, [courseId, userId]);
+export const unenrollCourse = (courseId: number) => deleteData('enrollCourse', {}, courseId);
+export const unenrollCourseAdmin = (courseId: number, userId: number) =>
+  deleteData('enrollCourseAdmin', {}, [courseId, userId]);
 export const getUserCourses = (userId: number) => fetchData('userCourses', {}, userId);
 export const getCourseProgress = (courseId: number) => fetchData('courseProgress', {}, courseId);
 export const getCourseTests = (courseId: number) => fetchData('courseTests', {}, courseId);

--- a/src/pages/course-access-admin/CourseAccessAdminPage.tsx
+++ b/src/pages/course-access-admin/CourseAccessAdminPage.tsx
@@ -19,7 +19,7 @@ import { Search as SearchIcon } from '@mui/icons-material';
 import MainCard from '../../components/MainCard';
 import { Table } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
-import { getCourses, enrollCourseAdmin, getUserCourses } from 'api';
+import { getCourses, enrollCourseAdmin, unenrollCourseAdmin, getUserCourses } from 'api';
 import { Context } from '../..';
 import { observer } from 'mobx-react-lite';
 
@@ -118,10 +118,14 @@ const CourseAccessAdminPage = observer(() => {
     setSelectedUser(null);
   };
 
-  const handleGrantCourse = async (courseIdParam: number) => {
+  const handleGrantCourse = async (courseIdParam: number, hasCourse: boolean) => {
     if (!selectedUser) return;
     try {
-      await enrollCourseAdmin(courseIdParam, selectedUser.id);
+      if (hasCourse) {
+        await unenrollCourseAdmin(courseIdParam, selectedUser.id);
+      } else {
+        await enrollCourseAdmin(courseIdParam, selectedUser.id);
+      }
       const ucs = await getUserCourses(selectedUser.id);
       setUserCourses((prev) =>
         prev.map((uc) =>
@@ -210,19 +214,19 @@ const CourseAccessAdminPage = observer(() => {
       </MainCard>
       <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)} onClose={handleCloseMenu}>
         {courses.map((c) => {
-          const hasCourse = selectedUser && userCourses.find((uc) => uc.user.id === selectedUser.id)?.courses.some((sc) => sc.id === c.id);
+          const hasCourse =
+            selectedUser && userCourses.find((uc) => uc.user.id === selectedUser.id)?.courses.some((sc) => sc.id === c.id);
           return (
             <MenuItem
               key={c.id}
-              onClick={() => handleGrantCourse(c.id)}
-              disabled={hasCourse}
+              onClick={() => handleGrantCourse(c.id, !!hasCourse)}
               selected={hasCourse}
               sx={{
                 fontWeight: hasCourse ? 600 : 'normal',
                 opacity: hasCourse ? 0.6 : 1
               }}
             >
-              {c.title}
+              {hasCourse ? `Удалить доступ: ${c.title}` : c.title}
             </MenuItem>
           );
         })}

--- a/src/pages/course-editor-page/CourseEditorPage.tsx
+++ b/src/pages/course-editor-page/CourseEditorPage.tsx
@@ -31,6 +31,8 @@ const CourseEditorPage = () => {
           title: c.title,
           description: c.description || '',
           accessType: 'public',
+          image: typeof c.image === 'string' ? c.image : c.image?.path || '',
+          imageId: c.img_id || null,
           modules: modulesWithLessons.map((m: any) => ({
             id: m.id,
             title: m.title,

--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -55,7 +55,8 @@ const CoursesPage = () => {
       const { courses: data, current } = await getCourses();
       const formatted = data.map((c: any) => ({
         ...c,
-        image: typeof c.image === 'string' ? c.image : c.image?.path || null
+        image: typeof c.image === 'string' ? c.image : c.image?.path || null,
+        students: Array.isArray(c.students) ? c.students.length : c.students ?? c.students_count ?? 0
       }));
       setCourses(formatted);
       const last = current?.course ? formatted.find((c: any) => c.id === current.course.id) || null : null;

--- a/src/pages/lessons-page/LessonsPage.tsx
+++ b/src/pages/lessons-page/LessonsPage.tsx
@@ -103,7 +103,8 @@ const LessonsPage = () => {
               </CardHeader>
               <CardContent>
                 <Button
-                  className="w-full bg-green-600 hover:bg-green-700 text-white"
+                  className="w-full"
+                  variant={lesson.completed ? 'outline' : 'default'}
                   onClick={() =>
                     navigate(
                       `/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}`

--- a/src/pages/modules-page/ModulesPage.tsx
+++ b/src/pages/modules-page/ModulesPage.tsx
@@ -244,7 +244,7 @@ const ModulesPage = () => {
                         </span>
                         <Button
                           size="sm"
-                          className="bg-green-600 hover:bg-green-700 text-white"
+                          variant={completed ? 'outline' : 'default'}
                           onClick={() => navigate(`/courses/${courseId}/modules/${m.id}/lessons/${lesson.id}`)}
                         >
                           <Play className="h-4 w-4 mr-1" /> {completed ? 'Повторить' : 'Начать'}


### PR DESCRIPTION
## Summary
- show existing course image while editing
- improve lessons' "repeat" button styling
- refresh course list with student counts
- allow admin to revoke course access from menu
- add API helpers for unenrolling

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686546610d408322bdb887500cc7b238