### PR TITLE
Add course test management UI

### DIFF
--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -256,6 +256,11 @@ export const getUserCourses = (userId: number) => fetchData('userCourses', {}, u
 export const getCourseProgress = (courseId: number) => fetchData('courseProgress', {}, courseId);
 export const getCourseTests = (courseId: number) => fetchData('courseTests', {}, courseId);
 export const postCourseTest = (courseId: number, d: any) => postData('courseTests', d, courseId);
+export const getCourseTest = (courseId: number, testId: number) =>
+  fetchData('courseTestById', {}, [courseId, testId]);
+export const deleteCourseTest = (courseId: number, testId: number) =>
+  deleteData('courseTestById', {}, [courseId, testId]);
+export const getTests = () => fetchData('getTests');
 export const getModuleProgress = (moduleId: number) => fetchData('moduleProgress', {}, moduleId);
 export const getModuleTests = (moduleId: number) => fetchData('moduleTests', {}, moduleId);
 export const postModuleTest = (moduleId: number, d: any) => postData('moduleTests', d, moduleId);

--- a/src/endpoints/index.tsx
+++ b/src/endpoints/index.tsx
@@ -104,6 +104,10 @@ const endpoints = {
   userCourses: (userId: string | number) => `api/courses/users/${userId}/courses/`,
   courseProgress: (courseId: string | number) => `api/courses/${courseId}/progress/`,
   courseTests: (courseId: string | number) => `api/courses/${courseId}/tests/`,
+  courseTestById: (
+    courseId: string | number,
+    testId: string | number,
+  ) => `api/courses/${courseId}/tests/${testId}/`,
 
   moduleProgress: (moduleId: string | number) => `api/modules/${moduleId}/progress/`,
   moduleTests: (moduleId: string | number) => `api/modules/${moduleId}/tests/`,


### PR DESCRIPTION
## Summary
- support course test fetch & remove endpoints
- fetch course tests when starting a course test
- expose route for course test page
- allow admin to attach/detach tests to courses
- show attached tests on course page once course is completed

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb42faf4c832295cd2285a19df556