### PR TITLE
Fix single column layout for courses

### DIFF
--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -223,7 +223,7 @@ const CoursesPage = () => {
             />
           </Box>
         </div>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid gap-6">
           {displayCourses.map((course, index) => {
             const hasAccess = roleCode === 'admin' || course.enrolled;
             return (


### PR DESCRIPTION
## Summary
- ensure courses list uses a single-column layout

## Testing
- `yarn lint` *(fails: Parsing error: Missing semicolon)*

------
https://chatgpt.com/codex/tasks/task_e_686e38b1f0b88322830a145280fe1788