### PR TITLE
Remove lesson completion and access controls

### DIFF
--- a/src/components/CourseFormDialog.tsx
+++ b/src/components/CourseFormDialog.tsx
@@ -8,11 +8,7 @@ import {
   TextField,
   Stack,
   Typography,
-  IconButton,
-  Select,
-  MenuItem,
-  InputLabel,
-  FormControl
+  IconButton
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -24,9 +20,6 @@ interface LessonForm {
   id?: number;
   title: string;
   content?: string;
-  video?: string;
-  image?: string;
-  imageId?: number;
 }
 
 interface ModuleForm {
@@ -38,8 +31,6 @@ interface ModuleForm {
 export interface CourseFormData {
   title: string;
   description?: string;
-  accessType: 'public' | 'group' | 'user';
-  accessId?: string;
   imageId?: number;
   image?: string;
   modules: ModuleForm[];
@@ -52,14 +43,12 @@ interface CourseFormDialogProps {
   course?: CourseFormData;
 }
 
-const emptyLesson = (): LessonForm => ({ title: '', content: '', video: '' });
+const emptyLesson = (): LessonForm => ({ title: '', content: '' });
 const emptyModule = (): ModuleForm => ({ title: '', lessons: [] });
 
 const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSave, course }) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [accessType, setAccessType] = useState<'public' | 'group' | 'user'>('public');
-  const [accessId, setAccessId] = useState('');
   const [modules, setModules] = useState<ModuleForm[]>([emptyModule()]);
   const [courseImage, setCourseImage] = useState<string>('');
   const [courseImageFile, setCourseImageFile] = useState<File | null>(null);
@@ -73,8 +62,6 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
     if (course) {
       setTitle(course.title);
       setDescription(course.description || '');
-      setAccessType(course.accessType);
-      setAccessId(course.accessId || '');
       setModules(
         course.modules.length
           ? course.modules.map((m) => ({ id: m.id, title: m.title, lessons: m.lessons || [] }))
@@ -92,8 +79,6 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
     } else if (open) {
       setTitle('');
       setDescription('');
-      setAccessType('public');
-      setAccessId('');
       setModules([emptyModule()]);
       setCourseImage('');
       setCourseImageId(null);
@@ -159,8 +144,6 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
     onSave({
       title,
       description,
-      accessType,
-      accessId,
       image: courseImage,
       imageId: courseImageId ?? undefined,
       modules
@@ -212,26 +195,6 @@ const CourseFormDialog: React.FC<CourseFormDialogProps> = ({ open, onClose, onSa
               )}
               {courseImage && <img src={courseImage} alt="course" style={{ height: 40 }} />}
             </Stack>
-            <FormControl>
-              <InputLabel id="access-label">Права доступа</InputLabel>
-              <Select
-                labelId="access-label"
-                value={accessType}
-                label="Права доступа"
-                onChange={(e) => setAccessType(e.target.value as any)}
-              >
-                <MenuItem value="public">Общий</MenuItem>
-                <MenuItem value="group">Для группы</MenuItem>
-                <MenuItem value="user">Для пользователя</MenuItem>
-              </Select>
-            </FormControl>
-            {(accessType === 'group' || accessType === 'user') && (
-              <TextField
-                label={accessType === 'group' ? 'ID группы' : 'ID пользователя'}
-                value={accessId}
-                onChange={(e) => setAccessId(e.target.value)}
-              />
-            )}
             <Typography variant="h6">Модули и уроки</Typography>
             {modules.map((mod, modIndex) => (
               <Stack key={modIndex} spacing={1} sx={{ border: '1px solid #ccc', p: 2, borderRadius: 1 }}>

--- a/src/components/LessonFormDialog.tsx
+++ b/src/components/LessonFormDialog.tsx
@@ -1,16 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button, Stack, IconButton } from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
+import { Dialog, DialogTitle, DialogContent, DialogActions, TextField, Button, Stack } from '@mui/material';
 import JoditEditor from 'jodit-react';
-import { postData } from '../api';
 
 export interface LessonFormData {
   id?: number;
   title: string;
   content?: string;
-  video?: string;
-  image?: string;
-  imageId?: number;
 }
 
 interface LessonFormDialogProps {
@@ -23,47 +18,20 @@ interface LessonFormDialogProps {
 const LessonFormDialog: React.FC<LessonFormDialogProps> = ({ open, onClose, onSave, lesson }) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const [video, setVideo] = useState('');
-  const [image, setImage] = useState<string>('');
-  const [imageId, setImageId] = useState<number | null>(null);
-  const [imageFile, setImageFile] = useState<File | null>(null);
   const editor = useRef<any>(null);
 
   useEffect(() => {
     if (lesson) {
       setTitle(lesson.title);
       setContent(lesson.content || '');
-      setVideo(lesson.video || '');
-      setImage(lesson.image || '');
-      setImageId(lesson.imageId ?? null);
     } else if (open) {
       setTitle('');
       setContent('');
-      setVideo('');
-      setImage('');
-      setImageId(null);
-      setImageFile(null);
     }
   }, [lesson, open]);
 
-  const handleUpload = async () => {
-    if (!imageFile) return;
-    const formData = new FormData();
-    formData.append('file', imageFile);
-    try {
-      const res = await postData('uploadLogo', formData);
-      if (res && res.url) {
-        setImage(res.url);
-        if (res.id) setImageId(res.id);
-        setImageFile(null);
-      }
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
   const handleSave = () => {
-    onSave({ id: lesson?.id, title, content, video, image, imageId: imageId ?? undefined });
+    onSave({ id: lesson?.id, title, content });
   };
 
   return (
@@ -72,24 +40,6 @@ const LessonFormDialog: React.FC<LessonFormDialogProps> = ({ open, onClose, onSa
       <DialogContent dividers>
         <Stack spacing={2} sx={{ mt: 1 }}>
           <TextField fullWidth label="Название" value={title} onChange={(e) => setTitle(e.target.value)} />
-          <TextField fullWidth label="Ссылка на видео" value={video} onChange={(e) => setVideo(e.target.value)} />
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Button variant="outlined" component="label" size="small">
-              Картинка
-              <input type="file" hidden accept="image/*" onChange={(e) => setImageFile(e.target.files?.[0] || null)} />
-            </Button>
-            {imageFile && (
-              <Button variant="contained" color="primary" onClick={handleUpload}>
-                Загрузить
-              </Button>
-            )}
-            {image && <img src={image} alt="lesson" style={{ height: 40 }} />}
-            {image && (
-              <IconButton onClick={() => setImage('')} size="small">
-                <DeleteIcon />
-              </IconButton>
-            )}
-          </Stack>
           <JoditEditor ref={editor} value={content} onBlur={(newContent) => setContent(newContent)} />
         </Stack>
       </DialogContent>

--- a/src/pages/course-editor-page/CourseEditorPage.tsx
+++ b/src/pages/course-editor-page/CourseEditorPage.tsx
@@ -30,7 +30,6 @@ const CourseEditorPage = () => {
         const formData: CourseFormData = {
           title: c.title,
           description: c.description || '',
-          accessType: 'public',
           modules: modulesWithLessons.map((m: any) => ({
             id: m.id,
             title: m.title,
@@ -39,7 +38,6 @@ const CourseEditorPage = () => {
                 id: l.id,
                 title: l.title,
                 content: l.content || '',
-                video: l.video || '',
                 image: l.image || '',
                 imageId: l.img_id || null
               })) || []
@@ -59,14 +57,12 @@ const CourseEditorPage = () => {
       if (editingId) {
         await putCourse(editingId, { title: data.title, description: data.description, img_id: data.imageId });
       } else {
-        const res = await postCourse({
-          title: data.title,
-          description: data.description,
-          accessType: data.accessType,
-          accessId: data.accessId,
-          img_id: data.imageId,
-          image: data.image
-        });
+          const res = await postCourse({
+            title: data.title,
+            description: data.description,
+            img_id: data.imageId,
+            image: data.image
+          });
         id = res?.id;
       }
       if (id) {
@@ -89,12 +85,11 @@ const CourseEditorPage = () => {
           if (modId) {
             const validLessons = (mod.lessons || []).filter((l) => l.title.trim());
             for (const les of validLessons) {
-              const payload = {
-                title: les.title,
-                content: les.content,
-                video: les.video,
-                imgId: les.imageId
-              };
+                const payload = {
+                  title: les.title,
+                  content: les.content,
+                  imgId: les.imageId
+                };
               if (les.id) {
                 await putLesson(les.id, payload);
               } else {

--- a/src/pages/courses-page/CoursesPage.tsx
+++ b/src/pages/courses-page/CoursesPage.tsx
@@ -99,7 +99,6 @@ const CoursesPage = () => {
           course: {
             title: course.title,
             description: course.description || '',
-            accessType: 'public',
             modules: modulesWithLessons.map((m: any) => ({
               id: m.id,
               title: m.title,
@@ -109,7 +108,6 @@ const CoursesPage = () => {
                   id: l.id,
                   title: l.title,
                   content: l.content || '',
-                  video: l.video || '',
                   image: l.image || ''
                 })) || []
             }))

--- a/src/pages/courses-page/CoursesPage_old.tsx
+++ b/src/pages/courses-page/CoursesPage_old.tsx
@@ -106,7 +106,6 @@ const CoursesPage = () => {
   const [editingLessonId, setEditingLessonId] = useState<number | null>(null);
   const [lessonTitle, setLessonTitle] = useState('');
   const [lessonContent, setLessonContent] = useState('');
-  const [lessonVideo, setLessonVideo] = useState('');
   const editor = useRef(null);
 
   const handleCreateTestForCourse = (courseId: number) => {
@@ -295,18 +294,17 @@ const CoursesPage = () => {
       const formData: CourseFormData = {
         title: course.title,
         description: course.description || '',
-        accessType: 'public',
-        modules: modulesWithLessons.map((m) => ({
-          id: m.id,
-          title: m.title,
-          description: m.description || '',
-          lessons: m.lessons?.map((l) => ({ id: l.id, title: l.title, content: l.content || '', video: l.video || '' })) || []
-        }))
-      };
+          modules: modulesWithLessons.map((m) => ({
+            id: m.id,
+            title: m.title,
+            description: m.description || '',
+            lessons: m.lessons?.map((l) => ({ id: l.id, title: l.title, content: l.content || '' })) || []
+          }))
+        };
       setCourseFormData(formData);
     } catch (e) {
       console.error(e);
-      setCourseFormData({ title: course.title, description: course.description || '', accessType: 'public', modules: [] });
+      setCourseFormData({ title: course.title, description: course.description || '', modules: [] });
     }
     setOpenCourseDialog(true);
   };
@@ -330,13 +328,13 @@ const CoursesPage = () => {
           modId = m?.id;
         }
         if (!modId) continue;
-        for (const les of mod.lessons) {
-          if (les.id) {
-            await putLesson(les.id, { title: les.title, content: les.content, video: les.video });
-          } else {
-            await postLesson(modId, { title: les.title, content: les.content, video: les.video });
+          for (const les of mod.lessons) {
+            if (les.id) {
+              await putLesson(les.id, { title: les.title, content: les.content });
+            } else {
+              await postLesson(modId, { title: les.title, content: les.content });
+            }
           }
-        }
       }
       setOpenCourseDialog(false);
       setEditingCourseId(null);
@@ -416,7 +414,6 @@ const CoursesPage = () => {
     setEditingLessonId(null);
     setLessonTitle('');
     setLessonContent('');
-    setLessonVideo('');
     setOpenLessonDialog(true);
   };
 
@@ -426,7 +423,6 @@ const CoursesPage = () => {
     setEditingLessonId(lesson.id);
     setLessonTitle(lesson.title);
     setLessonContent(lesson.content || '');
-    setLessonVideo(lesson.video || '');
     setOpenLessonDialog(true);
   };
 
@@ -435,20 +431,18 @@ const CoursesPage = () => {
     setEditingLessonId(null);
     setLessonTitle('');
     setLessonContent('');
-    setLessonVideo('');
   };
 
   const saveLesson = async () => {
     if (!lessonModuleId) return;
     try {
-      const payload = { title: lessonTitle, content: lessonContent, video: lessonVideo };
+    const payload = { title: lessonTitle, content: lessonContent };
       if (editingLessonId) {
         await putLesson(editingLessonId, payload);
       } else {
         await postLesson(lessonModuleId, payload);
       }
-      setOpenLessonDialog(false);
-      setLessonVideo('');
+        setOpenLessonDialog(false);
       const lessonsData = await getLessons(lessonModuleId);
       setCourses((prev) =>
         prev.map((c) =>

--- a/src/pages/lessons-page/LessonViewPage.tsx
+++ b/src/pages/lessons-page/LessonViewPage.tsx
@@ -104,26 +104,9 @@ const LessonViewPage = () => {
           </Button>
         </div>
         <div className="mt-6 text-right">
-          {lesson.completed ? (
+          {lesson.completed && (
             <Button variant="outline" disabled>
               <CheckCircle className="h-4 w-4 mr-2" /> Урок пройден
-            </Button>
-          ) : (
-            <Button
-              variant="default"
-              onClick={async () => {
-                try {
-                  await completeLesson(lesson.id);
-                  setLesson((prev) =>
-                    prev ? { ...prev, completed: true } : prev
-                  );
-                } catch (e) {
-                  console.error(e);
-                }
-                navigate(-1);
-              }}
-            >
-              <CheckCircle className="h-4 w-4 mr-2" /> Завершить урок
             </Button>
           )}
         </div>

--- a/src/pages/modules-page/ModulesPage.tsx
+++ b/src/pages/modules-page/ModulesPage.tsx
@@ -13,7 +13,6 @@ interface Lesson {
   id: number;
   title: string;
   content?: string;
-  video?: string;
   image?: string;
   imageId?: number;
   completed?: boolean;
@@ -125,7 +124,6 @@ const ModulesPage = () => {
       id: lesson.id,
       title: lesson.title,
       content: (lesson as any).content || '',
-      video: (lesson as any).video || '',
       image: (lesson as any).image,
       imageId: (lesson as any).img_id || lesson.imageId
     });
@@ -135,12 +133,11 @@ const ModulesPage = () => {
   const saveLesson = async (data: LessonFormData) => {
     if (!currentModuleId) return;
     try {
-      const payload = {
-        title: data.title,
-        content: data.content,
-        video: data.video,
-        imgId: data.imageId
-      };
+    const payload = {
+      title: data.title,
+      content: data.content,
+      imgId: data.imageId
+    };
       if (data.id) {
         await putLesson(data.id, payload);
       } else {


### PR DESCRIPTION
## Summary
- remove "Завершить урок" action from lesson view
- simplify lesson form by removing video and image fields
- drop access-rights fields in course form
- update pages to handle changed lesson/course data models

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_686e501319708322bd2df893f0b3f27a