### PR TITLE
Implement FAQ page

### DIFF
--- a/src/api/index.tsx
+++ b/src/api/index.tsx
@@ -258,5 +258,16 @@ export const getModuleTests = (moduleId: number) => fetchData('moduleTests', {},
 export const postModuleTest = (moduleId: number, d: any) => postData('moduleTests', d, moduleId);
 export const completeLesson = (lessonId: number) => postData('lessonComplete', {}, lessonId);
 
+export const getFaqCategories = () => fetchData('faqCategories');
+export const postFaqCategory = (data: any) => postData('faqCategories', data);
+export const putFaqCategory = (id: number, d: any) => putData('faqCategoryById', d, id);
+export const deleteFaqCategory = (id: number) => deleteData('faqCategoryById', {}, id);
+
+export const getFaqs = (categoryId?: number) =>
+  fetchData('faq', categoryId ? { category_id: categoryId } : {});
+export const postFaq = (data: any) => postData('faq', data);
+export const getFaq = (id: number) => fetchData('faqById', {}, id);
+export const putFaqAnswer = (id: number, d: any) => putData('faqAnswer', d, id);
+
 export const getTestImportTemplate = () => fetchData('getTestImportTemplate');
 export const postTestImportExcel = (formData: FormData) => postData('postTestImportExcel', formData);

--- a/src/endpoints/index.tsx
+++ b/src/endpoints/index.tsx
@@ -110,6 +110,13 @@ const endpoints = {
 
   lessonComplete: (lessonId: string | number) => `api/lessons/${lessonId}/complete/`,
 
+  /* FAQ */
+  faq: 'api/faq/',
+  faqById: (id: string | number) => `api/faq/${id}/`,
+  faqAnswer: (id: string | number) => `api/faq/${id}/answer/`,
+  faqCategories: 'api/faq-categories/',
+  faqCategoryById: (id: string | number) => `api/faq-categories/${id}/`,
+
   // Импорт/экспорт вопросов через Excel
   getTestImportTemplate: 'api/test-import/template/',
   postTestImportExcel: 'api/test-import/excel/',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,6 +44,7 @@ import questionsStore from './store/questionsStore';
 import AdminStore from './store/adminStore';
 import AccessTestToUserStore from './store/accessTestToUserStore';
 import AnalyticsStore from './store/analyticsStore';
+import FaqStore from './store/faqStore';
 
 const showAlert = (message: string, severity: 'success' | 'error') => {
   // This will be implemented by each component that needs alerts
@@ -62,6 +63,7 @@ const respondentsStore = new RespondentsStore(showAlert);
 const adminStore = new AdminStore();
 const accessTestToUserStore = new AccessTestToUserStore();
 const analyticsStore = new AnalyticsStore();
+const faqStore = new FaqStore();
 
 
 const obStore = {
@@ -80,7 +82,8 @@ const obStore = {
   respondentsStore,
   adminStore,
   accessTestToUserStore,
-  analyticsStore
+  analyticsStore,
+  faqStore
 }
 
 export const Context = createContext(obStore);

--- a/src/interface/interfaceStore.ts
+++ b/src/interface/interfaceStore.ts
@@ -375,3 +375,22 @@ export interface IQuestionTypes {
   updated_at: string;
 }
 
+export interface IFaqCategory {
+  id: number;
+  title: string;
+  user_group_id: number | null;
+  express?: boolean | null;
+}
+
+export interface IFaq {
+  id: number;
+  category_id: number;
+  username?: string | null;
+  question?: string | null;
+  date: string;
+  answer?: string | null;
+  hits: number;
+  active: boolean;
+  owner_id: number;
+}
+

--- a/src/menu-items/dashboard.jsx
+++ b/src/menu-items/dashboard.jsx
@@ -6,6 +6,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import QueryStatsIcon from '@mui/icons-material/QueryStats';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 
 
 // icons
@@ -17,7 +18,8 @@ const icons = {
   SettingsIcon,
   LibraryBooksIcon,
   AdminPanelSettingsIcon,
-  QueryStatsIcon
+  QueryStatsIcon,
+  HelpOutlineIcon
 };
 
 // ==============================|| MENU ITEMS - DASHBOARD ||============================== //
@@ -76,6 +78,16 @@ const dashboard = {
       breadcrumbs: true,
       code: 'anyCode',
       allowedRoles: ['admin', 'moderator']
+    },
+    {
+      id: '9',
+      title: 'FAQ',
+      type: 'item',
+      url: '/faq',
+      icon: icons.HelpOutlineIcon,
+      breadcrumbs: true,
+      code: 'anyCode',
+      allowedRoles: ['admin', 'user', 'guest', 'moderator']
     },
     {
       id: '4',

--- a/src/pages/faq-page/FaqPage.tsx
+++ b/src/pages/faq-page/FaqPage.tsx
@@ -1,0 +1,211 @@
+import React, { useEffect, useState, useContext } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Typography,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  IconButton,
+  Menu,
+  MenuItem,
+  List,
+  ListItem,
+  ListItemText,
+  Stack
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import MainCard from '../../components/MainCard';
+import { Context } from '../..';
+import { observer } from 'mobx-react-lite';
+import { IFaqCategory } from '../../interface/interfaceStore';
+
+const FaqPage = observer(() => {
+  const { faqStore, authStore } = useContext(Context);
+  const [selectedCategory, setSelectedCategory] = useState<number | null>(null);
+
+  const [categoryDialogOpen, setCategoryDialogOpen] = useState(false);
+  const [categoryTitle, setCategoryTitle] = useState('');
+  const [editingCategory, setEditingCategory] = useState<IFaqCategory | null>(null);
+
+  const [questionDialogOpen, setQuestionDialogOpen] = useState(false);
+  const [questionText, setQuestionText] = useState('');
+
+  const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
+  const [menuCategoryId, setMenuCategoryId] = useState<number | null>(null);
+
+  useEffect(() => {
+    faqStore.fetchCategories();
+  }, [faqStore]);
+
+  useEffect(() => {
+    if (selectedCategory !== null) {
+      faqStore.fetchFaqs(selectedCategory, true);
+    }
+  }, [selectedCategory, faqStore]);
+
+  const handleOpenCategoryDialog = (cat?: IFaqCategory) => {
+    setEditingCategory(cat || null);
+    setCategoryTitle(cat?.title || '');
+    setCategoryDialogOpen(true);
+  };
+
+  const handleSaveCategory = async () => {
+    if (editingCategory) {
+      await faqStore.updateCategory(editingCategory.id, { title: categoryTitle });
+    } else {
+      await faqStore.createCategory({ title: categoryTitle, user_group_id: null, express: false });
+    }
+    setCategoryDialogOpen(false);
+    setCategoryTitle('');
+    setEditingCategory(null);
+  };
+
+  const handleDeleteCategory = async (id: number) => {
+    await faqStore.removeCategory(id);
+    if (selectedCategory === id) setSelectedCategory(null);
+    setMenuAnchor(null);
+  };
+
+  const handleAskQuestion = async () => {
+    if (selectedCategory !== null) {
+      await faqStore.createFaq({ category_id: selectedCategory, question: questionText });
+      setQuestionText('');
+      setQuestionDialogOpen(false);
+    }
+  };
+
+  return (
+    <Box>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems="flex-start">
+        <Box sx={{ minWidth: 250 }}>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1}>
+            <Typography variant="h6">Категории</Typography>
+            {authStore.roleCode === 'admin' && (
+              <IconButton onClick={() => handleOpenCategoryDialog()} size="small">
+                <AddIcon />
+              </IconButton>
+            )}
+          </Stack>
+          <List>
+            {faqStore.categories.map((cat) => (
+              <ListItem
+                button
+                key={cat.id}
+                selected={selectedCategory === cat.id}
+                onClick={() => setSelectedCategory(cat.id)}
+                secondaryAction={
+                  authStore.roleCode === 'admin' && (
+                    <IconButton
+                      edge="end"
+                      onClick={(e) => {
+                        setMenuCategoryId(cat.id);
+                        setMenuAnchor(e.currentTarget);
+                      }}
+                    >
+                      <MoreVertIcon />
+                    </IconButton>
+                  )
+                }
+              >
+                <ListItemText primary={cat.title} />
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+
+        <Box flexGrow={1}>
+          {selectedCategory !== null && (
+            <>
+              <Stack direction="row" justifyContent="space-between" alignItems="center" mb={2}>
+                <Typography variant="h6">Вопросы</Typography>
+                <Button variant="outlined" onClick={() => setQuestionDialogOpen(true)}>
+                  Задать вопрос
+                </Button>
+              </Stack>
+              {faqStore.faqs.map((f) => (
+                <Card key={f.id} sx={{ mb: 2 }}>
+                  <CardHeader title={f.question} subheader={f.username} />
+                  <CardContent>
+                    {f.answer ? (
+                      <Typography>{f.answer}</Typography>
+                    ) : (
+                      <Typography color="text.secondary">Нет ответа</Typography>
+                    )}
+                  </CardContent>
+                </Card>
+              ))}
+            </>
+          )}
+        </Box>
+      </Stack>
+
+      <Dialog open={categoryDialogOpen} onClose={() => setCategoryDialogOpen(false)}>
+        <DialogTitle>{editingCategory ? 'Редактировать категорию' : 'Новая категория'}</DialogTitle>
+        <DialogContent>
+          <TextField
+            margin="dense"
+            label="Название"
+            fullWidth
+            value={categoryTitle}
+            onChange={(e) => setCategoryTitle(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCategoryDialogOpen(false)}>Отмена</Button>
+          <Button onClick={handleSaveCategory} variant="contained" color="success">
+            Сохранить
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={questionDialogOpen} onClose={() => setQuestionDialogOpen(false)}>
+        <DialogTitle>Задать вопрос</DialogTitle>
+        <DialogContent>
+          <TextField
+            margin="dense"
+            label="Вопрос"
+            fullWidth
+            multiline
+            minRows={3}
+            value={questionText}
+            onChange={(e) => setQuestionText(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setQuestionDialogOpen(false)}>Отмена</Button>
+          <Button onClick={handleAskQuestion} variant="contained" color="success">
+            Отправить
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Menu anchorEl={menuAnchor} open={Boolean(menuAnchor)} onClose={() => setMenuAnchor(null)}>
+        <MenuItem
+          onClick={() => {
+            const cat = faqStore.categories.find((c) => c.id === menuCategoryId);
+            if (cat) handleOpenCategoryDialog(cat);
+            setMenuAnchor(null);
+          }}
+        >
+          Редактировать
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (menuCategoryId) handleDeleteCategory(menuCategoryId);
+          }}
+        >
+          Удалить
+        </MenuItem>
+      </Menu>
+    </Box>
+  );
+});
+
+export default FaqPage;

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -16,6 +16,7 @@ import CreateRespondentsPage from 'pages/respondents-page/create-respondents-lis
 import AdminPage from 'pages/admin-page/AdminPage';
 import CourseAccessAdminPage from 'pages/course-access-admin/CourseAccessAdminPage';
 import AnalyticsPage from 'pages/analytics-page/AnalyticsPage';
+import FaqPage from 'pages/faq-page/FaqPage';
 
 // ==============================|| MAIN ROUTING ||============================== //
 
@@ -113,6 +114,10 @@ const MainRoutes = {
         {
           path: '/analytics',
           element: <AnalyticsPage />
+        },
+        {
+          path: '/faq',
+          element: <FaqPage />
         }
       ]
     }

--- a/src/store/faqStore.ts
+++ b/src/store/faqStore.ts
@@ -1,0 +1,104 @@
+import { makeAutoObservable, runInAction } from 'mobx';
+import { IFaq, IFaqCategory } from '../interface/interfaceStore';
+import {
+  getFaqCategories,
+  postFaqCategory,
+  putFaqCategory,
+  deleteFaqCategory,
+  getFaqs,
+  postFaq,
+  putFaqAnswer
+} from '../api';
+
+export default class FaqStore {
+  categories: IFaqCategory[] = [];
+  faqs: IFaq[] = [];
+  loadingCategories = false;
+  loadingFaqs = false;
+  error = '';
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  async fetchCategories(force = false) {
+    if (this.loadingCategories) return;
+    if (!force && this.categories.length > 0) return;
+    this.loadingCategories = true;
+    try {
+      const data = await getFaqCategories();
+      runInAction(() => {
+        this.categories = data;
+      });
+    } catch (e: any) {
+      runInAction(() => {
+        this.error = e.message ?? 'Ошибка при загрузке категорий';
+      });
+    } finally {
+      this.loadingCategories = false;
+    }
+  }
+
+  async createCategory(data: Omit<IFaqCategory, 'id'>) {
+    try {
+      await postFaqCategory(data);
+      await this.fetchCategories(true);
+    } catch (e: any) {
+      this.error = e.message ?? 'Ошибка при создании категории';
+    }
+  }
+
+  async updateCategory(id: number, data: Partial<IFaqCategory>) {
+    try {
+      await putFaqCategory(id, data);
+      await this.fetchCategories(true);
+    } catch (e: any) {
+      this.error = e.message ?? 'Ошибка при обновлении категории';
+    }
+  }
+
+  async removeCategory(id: number) {
+    try {
+      await deleteFaqCategory(id);
+      await this.fetchCategories(true);
+    } catch (e: any) {
+      this.error = e.message ?? 'Ошибка при удалении категории';
+    }
+  }
+
+  async fetchFaqs(categoryId?: number, force = false) {
+    if (this.loadingFaqs) return;
+    if (!force && this.faqs.length > 0 && categoryId === undefined) return;
+    this.loadingFaqs = true;
+    try {
+      const data = await getFaqs(categoryId);
+      runInAction(() => {
+        this.faqs = data;
+      });
+    } catch (e: any) {
+      runInAction(() => {
+        this.error = e.message ?? 'Ошибка при загрузке FAQ';
+      });
+    } finally {
+      this.loadingFaqs = false;
+    }
+  }
+
+  async createFaq(data: { category_id: number; question: string }) {
+    try {
+      await postFaq(data);
+      await this.fetchFaqs(data.category_id, true);
+    } catch (e: any) {
+      this.error = e.message ?? 'Ошибка при создании вопроса';
+    }
+  }
+
+  async answerFaq(id: number, data: { answer: string; active?: boolean }) {
+    try {
+      await putFaqAnswer(id, data);
+      await this.fetchFaqs(undefined, true);
+    } catch (e: any) {
+      this.error = e.message ?? 'Ошибка при ответе на вопрос';
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add FAQ endpoints
- expose new API helpers
- define IFaq and IFaqCategory interfaces
- create FaqStore and wire it into the app context
- implement FaqPage component
- register FAQ routes and menu item

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6881d27d23b48322948d8e854ee7d81e