### PR TITLE
Improve FAQ management

### DIFF
--- a/src/menu-items/dashboard.jsx
+++ b/src/menu-items/dashboard.jsx
@@ -119,6 +119,16 @@ const dashboard = {
       code: 'anyCode',
       allowedRoles: ['admin']
     },
+    {
+      id: '10',
+      title: 'Доступ к FAQ',
+      type: 'item',
+      url: '/admin/faq-access',
+      icon: icons.HelpOutlineIcon,
+      breadcrumbs: true,
+      code: 'anyCode',
+      allowedRoles: ['admin']
+    },
 
   ]
 };

--- a/src/pages/faq-page/FaqAccessPage.tsx
+++ b/src/pages/faq-page/FaqAccessPage.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect } from 'react';
+import { observer } from 'mobx-react-lite';
+import {
+  Box,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Select,
+  MenuItem
+} from '@mui/material';
+import MainCard from '../../components/MainCard';
+import { Context } from '../..';
+
+const FaqAccessPage = observer(() => {
+  const { faqStore, respondentsStore } = React.useContext(Context);
+
+  useEffect(() => {
+    faqStore.fetchCategories();
+    respondentsStore.getRespondentLists();
+  }, [faqStore, respondentsStore]);
+
+  const handleChange = (categoryId: number, groupId: string) => {
+    const value = groupId === '' ? null : Number(groupId);
+    faqStore.updateCategory(categoryId, { user_group_id: value });
+  };
+
+  return (
+    <Box>
+      <Typography variant="h5" sx={{ mb: 2 }}>
+        Права доступа к категориям FAQ
+      </Typography>
+      <MainCard>
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Категория</TableCell>
+                <TableCell>Группа</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {faqStore.categories.map((cat) => (
+                <TableRow key={cat.id}>
+                  <TableCell>{cat.title}</TableCell>
+                  <TableCell>
+                    <Select
+                      size="small"
+                      value={cat.user_group_id ?? ''}
+                      onChange={(e) => handleChange(cat.id, e.target.value as string)}
+                      displayEmpty
+                    >
+                      <MenuItem value="">Все</MenuItem>
+                      {respondentsStore.respondentListsArray.map((g) => (
+                        <MenuItem key={g.id} value={g.id.toString()}>
+                          {g.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </MainCard>
+    </Box>
+  );
+});
+
+export default FaqAccessPage;

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -17,6 +17,7 @@ import AdminPage from 'pages/admin-page/AdminPage';
 import CourseAccessAdminPage from 'pages/course-access-admin/CourseAccessAdminPage';
 import AnalyticsPage from 'pages/analytics-page/AnalyticsPage';
 import FaqPage from 'pages/faq-page/FaqPage';
+import FaqAccessPage from 'pages/faq-page/FaqAccessPage';
 
 // ==============================|| MAIN ROUTING ||============================== //
 
@@ -86,6 +87,10 @@ const MainRoutes = {
         {
           path: '/admin/course-access',
           element: <CourseAccessAdminPage />
+        },
+        {
+          path: '/admin/faq-access',
+          element: <FaqAccessPage />
         },
         {
           path: '/courses',


### PR DESCRIPTION
## Summary
- render HTML for FAQ questions and answers
- expand FAQ editors and allow setting user group on categories
- add page for FAQ category access management
- link FAQ access page in menu and routes

## Testing
- `yarn install` *(fails: lockfile would be modified)*
- `npx eslint "src/**/*.{js,jsx,ts,tsx}"` *(fails with parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68822c51e6348322a023e4c53e7d9b99